### PR TITLE
Fix plugin loading on Windows

### DIFF
--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -45,8 +45,8 @@ Core::Core(dynlib_t lib, std::string_view config_path, std::string_view data_pat
     init_core(config_path, data_path);
 }
 
-Core::Core(std::string_view lib_path, std::string_view config_path, std::string_view data_path)
-:handle_{load_library(std::string(lib_path).c_str())}
+Core::Core(const fs::directory_entry& lib_file, std::string_view config_path, std::string_view data_path)
+:handle_{load_library(lib_file)}
 {
     if(!handle_.lib)
     {
@@ -199,8 +199,8 @@ Plugin::Plugin(Core& core, dynlib_t lib)
     init_plugin(core.handle());
 }
 
-Plugin::Plugin(Core& core, std::string_view lib_path)
-:handle_{load_library(std::string(lib_path).c_str())}
+Plugin::Plugin(Core& core, const fs::directory_entry& lib_file)
+:handle_{load_library(lib_file)}
 {
     if(!handle_.lib)
     {
@@ -251,12 +251,15 @@ dynlib_t Plugin::handle()
     return handle_.lib;
 }
 
-PluginInfo Plugin::get_plugin_info(std::string_view lib_path)
+PluginInfo Plugin::get_plugin_info(const fs::directory_entry& file)
 {
-    auto lib{load_library(std::string(lib_path).c_str())};
+    auto lib{load_library(file)};
 
-    if(!lib)
-        return {};
+	if(!lib)
+	{
+		logger()->debug("Failed to load file {} as library: {}", file.path().filename(), get_lib_error_msg());
+		return {};
+	}
 
     auto ret{get_plugin_info(lib)};
     free_library(lib);

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <atomic>
+#include <experimental/filesystem>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -20,6 +21,8 @@
 
 namespace Core::Emulator
 {
+
+namespace fs = std::experimental::filesystem;
 
 /// Mupen64Plus API this frontend is compatible with
 constexpr int CORE_API_VERSION{0x020001};
@@ -90,7 +93,7 @@ struct Core
     Core(dynlib_t lib, std::string_view config_path, std::string_view data_path);
 
     /// Create core from library path
-    Core(std::string_view lib_path, std::string_view config_path, std::string_view data_path);
+    Core(const fs::directory_entry& lib_file, std::string_view config_path, std::string_view data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;
@@ -158,7 +161,7 @@ struct Plugin
     Plugin(Core& core, dynlib_t lib);
 
     /// Create plugin from library path
-    Plugin(Core& core, std::string_view lib_path);
+    Plugin(Core& core, const fs::directory_entry& lib_file);
 
     /// Non-copyable
     Plugin(const Plugin&) = delete;
@@ -177,7 +180,7 @@ struct Plugin
 
     dynlib_t handle();
 
-    static PluginInfo get_plugin_info(std::string_view lib_path);
+    static PluginInfo get_plugin_info(const fs::directory_entry& file);
     static PluginInfo get_plugin_info(dynlib_t lib);
 
     static const char* type_str(M64PTypes::m64p_plugin_type type_id);

--- a/src/core/emulator/shared_library.cpp
+++ b/src/core/emulator/shared_library.cpp
@@ -79,7 +79,15 @@ std::string get_lib_error_msg()
 
 dynlib_t load_library(const char* lib_path)
 {
-    return LoadLibraryA(lib_path);
+	// Disable the warning popup
+	auto old_error_mode{GetThreadErrorMode()};
+	SetThreadErrorMode(SEM_FAILCRITICALERRORS, nullptr);
+
+	auto lib{LoadLibraryA(lib_path)};
+
+	SetThreadErrorMode(old_error_mode, nullptr);
+
+	return lib;
 }
 
 dynlib_t get_current_process()

--- a/src/core/emulator/shared_library.hpp
+++ b/src/core/emulator/shared_library.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <experimental/filesystem>
 #include <string>
 
 #ifdef __linux__
@@ -20,6 +21,8 @@
 
 namespace Core::Emulator
 {
+
+namespace fs = std::experimental::filesystem;
 
 struct UniqueLib
 {
@@ -41,7 +44,7 @@ struct UniqueLib
     dynlib_t lib{nullptr};
 };
 
-dynlib_t load_library(const char* lib_path);
+dynlib_t load_library(const fs::directory_entry& lib_file);
 
 dynlib_t get_current_process();
 

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -24,20 +24,20 @@ MainFrame::MainFrame(QWidget* parent)
 
     for(const auto& entry : fs::directory_iterator(plugin_dir))
     {
-        const auto& path{entry.path()};
-        switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(path.string()).type)
+		auto path{ entry.path().string() };
+        switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry).type)
         {
         case M64PLUGIN_RSP:
-            ui->cbx_rsp_plugin->addItem(QString::fromStdString(path.filename().string()));
+            ui->cbx_rsp_plugin->addItem(QString::fromStdString(path));
             break;
         case M64PLUGIN_GFX:
-            ui->cbx_gfx_plugin->addItem(QString::fromStdString(path.filename().string()));
+            ui->cbx_gfx_plugin->addItem(QString::fromStdString(path));
             break;
         case M64PLUGIN_AUDIO:
-            ui->cbx_audio_plugin->addItem(QString::fromStdString(path.filename().string()));
+            ui->cbx_audio_plugin->addItem(QString::fromStdString(path));
             break;
         case M64PLUGIN_INPUT:
-            ui->cbx_input_plugin->addItem(QString::fromStdString(path.filename().string()));
+            ui->cbx_input_plugin->addItem(QString::fromStdString(path));
         default: break;
         }
     }
@@ -106,11 +106,10 @@ void MainFrame::on_btn_start_emu_clicked()
 
         emu_->load_rom(rom_image.data(), rom_image.size());
 
-        const char* plugin_dir{""};
-        emu_->add_plugin({emu_->core(), plugin_dir + ui->cbx_gfx_plugin->currentText().toStdString()});
-        emu_->add_plugin({emu_->core(), plugin_dir + ui->cbx_audio_plugin->currentText().toStdString()});
-        emu_->add_plugin({emu_->core(), plugin_dir + ui->cbx_rsp_plugin->currentText().toStdString()});
-        emu_->add_plugin({emu_->core(), plugin_dir + ui->cbx_input_plugin->currentText().toStdString()});
+		emu_->add_plugin({ emu_->core(), fs::directory_entry{ui->cbx_gfx_plugin->currentText().toStdString()}});
+		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_audio_plugin->currentText().toStdString()}});
+		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_rsp_plugin->currentText().toStdString()}});
+		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_input_plugin->currentText().toStdString()}});
 
         emulation_thread_ = std::async(std::launch::async, [this]()
         {

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -87,7 +87,7 @@ void MainFrame::on_btn_start_emu_clicked()
     try
     {
         emu_ = Core::Emulator::Mupen64Plus{{
-                "",
+                {},
                 "",
                 ""
         }};


### PR DESCRIPTION
On windows most plugins didn't load because their dependencies where located in the same folder as the plugin itself. Windows per default doesn't search the parent folder of a DLL so all plugins with external dependencies (SDL.dll, zlib.dll, ...) failed to load. As a fix I simply added the plugin folder to the list of searched directories.
Additionally I disabled the warning popups windows creates per default.