### PR TITLE
Add Mupen64Plus plugin configuration dialog

### DIFF
--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -45,7 +45,7 @@ Core::Core(dynlib_t lib, std::string config_path, std::string data_path)
     init_core();
 }
 
-Core::Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path)
+Core::Core(const fs::path& lib_file, std::string config_path, std::string data_path)
 :handle_{load_library(lib_file)}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
 {
     if(!handle_.lib)
@@ -201,7 +201,7 @@ Plugin::Plugin(Core& core, dynlib_t lib)
     init_plugin(core.handle());
 }
 
-Plugin::Plugin(Core& core, const fs::directory_entry& lib_file)
+Plugin::Plugin(Core& core, const fs::path& lib_file)
 :handle_{load_library(lib_file)}
 {
     if(!handle_.lib)

--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -45,8 +45,8 @@ Core::Core(dynlib_t lib, std::string config_path, std::string data_path)
     init_core();
 }
 
-Core::Core(const fs::path& lib_file, std::string config_path, std::string data_path)
-:handle_{load_library(lib_file)}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
+Core::Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path)
+:handle_{load_library(lib_file.path())}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
 {
     if(!handle_.lib)
     {

--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -627,7 +627,12 @@ const struct M64PlusErrorCategory : std::error_category
 
 } // anonymous
 
-std::error_code make_error_code(Core::Emulator::Mupen64Plus::Error e)
+namespace Core::Emulator::M64PlusHelper
+{
+
+std::error_code make_error_code(Error e)
 {
     return {static_cast<int>(e), m64p_error_category_g};
 }
+
+} // Core::Emulator::M64PlusHelper

--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -45,8 +45,8 @@ Core::Core(dynlib_t lib, std::string config_path, std::string data_path)
     init_core();
 }
 
-Core::Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path)
-:handle_{load_library(lib_file.path())}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
+Core::Core(const fs::path& lib_file, std::string config_path, std::string data_path)
+:handle_{load_library(lib_file)}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
 {
     if(!handle_.lib)
     {

--- a/src/core/emulator/m64plus.cpp
+++ b/src/core/emulator/m64plus.cpp
@@ -36,6 +36,8 @@ namespace M64PlusHelper
 Core::Core(std::string config_path, std::string data_path)
 :Core(get_current_process(), std::move(config_path), std::move(data_path))
 {
+    init_symbols();
+    init_core();
 }
 
 Core::Core(dynlib_t lib, std::string config_path, std::string data_path)
@@ -45,8 +47,8 @@ Core::Core(dynlib_t lib, std::string config_path, std::string data_path)
     init_core();
 }
 
-Core::Core(const fs::path& lib_file, std::string config_path, std::string data_path)
-:handle_{load_library(lib_file)}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
+Core::Core(const std::string& lib_path, std::string config_path, std::string data_path)
+:handle_{load_library(lib_path.c_str())}, config_path_{std::move(config_path)}, data_path_{std::move(data_path)}
 {
     if(!handle_.lib)
     {
@@ -201,8 +203,8 @@ Plugin::Plugin(Core& core, dynlib_t lib)
     init_plugin(core.handle());
 }
 
-Plugin::Plugin(Core& core, const fs::path& lib_file)
-:handle_{load_library(lib_file)}
+Plugin::Plugin(Core& core, const std::string& lib_path)
+:handle_{load_library(lib_path.c_str())}
 {
     if(!handle_.lib)
     {
@@ -253,13 +255,13 @@ dynlib_t Plugin::handle()
     return handle_.lib;
 }
 
-PluginInfo Plugin::get_plugin_info(const fs::directory_entry& file)
+PluginInfo Plugin::get_plugin_info(const std::string& file)
 {
-    auto lib{load_library(file)};
+    auto lib{load_library(file.c_str())};
 
 	if(!lib)
 	{
-		logger()->debug("Failed to load file {} as library: {}", file.path().filename(), get_lib_error_msg());
+		logger()->debug("Failed to load file {} as library: {}", file, get_lib_error_msg());
 		return {};
 	}
 

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -93,7 +93,7 @@ struct Core
     Core(dynlib_t lib, std::string config_path, std::string data_path);
 
     /// Create core from library file
-    Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path);
+    Core(const fs::path& lib_file, std::string config_path, std::string data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -92,8 +92,8 @@ struct Core
     /// Create core from dynamic library handle
     Core(dynlib_t lib, std::string config_path, std::string data_path);
 
-    /// Create core from library path
-    Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path);
+    /// Create core from library file
+    Core(const fs::path& lib_file, std::string config_path, std::string data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;
@@ -164,7 +164,7 @@ struct Plugin
     Plugin(Core& core, dynlib_t lib);
 
     /// Create plugin from library path
-    Plugin(Core& core, const fs::directory_entry& lib_file);
+    Plugin(Core& core, const fs::path& lib_file);
 
     /// Non-copyable
     Plugin(const Plugin&) = delete;

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -112,12 +112,15 @@ struct Core
 
     void detach_plugin(M64PTypes::m64p_plugin_type type);
 
+    /// Return pointer to n64 DRAM
     void* get_mem_ptr();
 
     Error do_cmd(M64PTypes::m64p_command cmd, int p1, void* p2);
 
+    /// Return native library handle
     dynlib_t handle();
 
+    /// Return general information about the core
     const PluginInfo& info() const;
 
 private:
@@ -179,13 +182,20 @@ struct Plugin
 
     friend void swap(Plugin& first, Plugin& second) noexcept;
 
+    /// Return general information about the plugin
     const PluginInfo& info() const;
 
+    /// Return native library handle
     dynlib_t handle();
 
+    /**
+     * Load file as plugin and return information about it.
+     * Returns type = M64PLUGIN_NULL if not a plugin
+     */
     static PluginInfo get_plugin_info(const std::string& file);
     static PluginInfo get_plugin_info(dynlib_t lib);
 
+    /// Get string representation of plugin type id
     static const char* type_str(M64PTypes::m64p_plugin_type type_id);
 
 
@@ -240,10 +250,13 @@ struct Mupen64Plus final : EmulatorBase
 
     friend void swap(Mupen64Plus& first, Mupen64Plus& second) noexcept;
 
+    /// Register a plugin
     void add_plugin(Plugin&& plugin);
 
+    /// Remove a plugin
     void remove_plugin(M64PTypes::m64p_plugin_type type);
 
+    /// Load ROM image
     void load_rom(void* rom_data, std::size_t n) override;
 
     void unload_rom() override;
@@ -262,6 +275,7 @@ struct Mupen64Plus final : EmulatorBase
 
     bool rom_loaded() const;
 
+    /// Check if plugin of a type is already registered
     bool has_plugin(M64PTypes::m64p_plugin_type type) const;
 
 private:

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -93,7 +93,7 @@ struct Core
     Core(dynlib_t lib, std::string config_path, std::string data_path);
 
     /// Create core from library file
-    Core(const fs::path& lib_file, std::string config_path, std::string data_path);
+    Core(const std::string& lib_path, std::string config_path, std::string data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;
@@ -164,7 +164,7 @@ struct Plugin
     Plugin(Core& core, dynlib_t lib);
 
     /// Create plugin from library path
-    Plugin(Core& core, const fs::path& lib_file);
+    Plugin(Core& core, const std::string& lib_path);
 
     /// Non-copyable
     Plugin(const Plugin&) = delete;
@@ -183,7 +183,7 @@ struct Plugin
 
     dynlib_t handle();
 
-    static PluginInfo get_plugin_info(const fs::directory_entry& file);
+    static PluginInfo get_plugin_info(const std::string& file);
     static PluginInfo get_plugin_info(dynlib_t lib);
 
     static const char* type_str(M64PTypes::m64p_plugin_type type_id);

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -63,6 +63,10 @@ enum struct Error
     SYM_NOT_FOUND    ///< A symbol required by the API could not be located in the specified module
 };
 
+/// Overload for Mupen64Plus error codes
+std::error_code make_error_code(Error e);
+
+
 /// Contains information retrieved via PluginGetVersion
 struct PluginInfo
 {
@@ -290,9 +294,6 @@ private:
 
 } // Core::Emulator
 
-
-/// Overload for Mupen64Plus error codes
-std::error_code make_error_code(Core::Emulator::Mupen64Plus::Error e);
 
 /// Specialization for Mupen64Plus error codes
 template<>

--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -93,7 +93,7 @@ struct Core
     Core(dynlib_t lib, std::string config_path, std::string data_path);
 
     /// Create core from library file
-    Core(const fs::path& lib_file, std::string config_path, std::string data_path);
+    Core(const fs::directory_entry& lib_file, std::string config_path, std::string data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;

--- a/src/core/emulator/shared_library.cpp
+++ b/src/core/emulator/shared_library.cpp
@@ -48,9 +48,9 @@ void UniqueLib::reset(dynlib_t hdl)
 
 #ifdef __linux__
 
-dynlib_t load_library(const fs::directory_entry& lib_file)
+dynlib_t load_library(const fs::path& lib_file)
 {
-    return dlopen(lib_file.path().string().c_str(), RTLD_LAZY);
+    return dlopen(lib_file.string().c_str(), RTLD_LAZY);
 }
 
 dynlib_t get_current_process()
@@ -77,7 +77,7 @@ std::string get_lib_error_msg()
 
 #elif defined _WIN32
 
-dynlib_t load_library(const fs::directory_entry& lib_file)
+dynlib_t load_library(const fs::path& lib_file)
 {
 	// Disable the warning popup
 	auto old_error_mode{ GetThreadErrorMode() };
@@ -85,9 +85,9 @@ dynlib_t load_library(const fs::directory_entry& lib_file)
 
 	// Add the file directory to the search path
 	// so that dependencies of the lib get loaded correctly
-	SetDllDirectoryA(lib_file.path().parent_path().string().c_str());
+	SetDllDirectoryA(lib_file.parent_path().string().c_str());
 
-	auto lib{ LoadLibraryA(lib_file.path().string().c_str()) };
+	auto lib{ LoadLibraryA(lib_file.string().c_str()) };
 
 	// Remove dir again
 	SetDllDirectory(nullptr);

--- a/src/core/emulator/shared_library.cpp
+++ b/src/core/emulator/shared_library.cpp
@@ -48,9 +48,9 @@ void UniqueLib::reset(dynlib_t hdl)
 
 #ifdef __linux__
 
-dynlib_t load_library(const fs::path& lib_file)
+dynlib_t load_library(const char* lib_file)
 {
-    return dlopen(lib_file.string().c_str(), RTLD_LAZY);
+    return dlopen(lib_file, RTLD_LAZY);
 }
 
 dynlib_t get_current_process()
@@ -77,17 +77,19 @@ std::string get_lib_error_msg()
 
 #elif defined _WIN32
 
-dynlib_t load_library(const fs::path& lib_file)
+dynlib_t load_library(const char* lib_file)
 {
+    fs::path lib_path{lib_file};
+
 	// Disable the warning popup
 	auto old_error_mode{ GetThreadErrorMode() };
 	SetThreadErrorMode(SEM_FAILCRITICALERRORS, nullptr);
 
 	// Add the file directory to the search path
 	// so that dependencies of the lib get loaded correctly
-	SetDllDirectoryA(lib_file.parent_path().string().c_str());
+	SetDllDirectoryA(lib_path.parent_path().string().c_str());
 
-	auto lib{ LoadLibraryA(lib_file.string().c_str()) };
+	auto lib{LoadLibraryA(lib_file)};
 
 	// Remove dir again
 	SetDllDirectory(nullptr);

--- a/src/core/emulator/shared_library.hpp
+++ b/src/core/emulator/shared_library.hpp
@@ -44,7 +44,7 @@ struct UniqueLib
     dynlib_t lib{nullptr};
 };
 
-dynlib_t load_library(const fs::directory_entry& lib_file);
+dynlib_t load_library(const fs::path& lib_file);
 
 dynlib_t get_current_process();
 

--- a/src/core/emulator/shared_library.hpp
+++ b/src/core/emulator/shared_library.hpp
@@ -44,7 +44,7 @@ struct UniqueLib
     dynlib_t lib{nullptr};
 };
 
-dynlib_t load_library(const fs::path& lib_file);
+dynlib_t load_library(const char* lib_file);
 
 dynlib_t get_current_process();
 

--- a/src/qt_gui/CMakeLists.txt
+++ b/src/qt_gui/CMakeLists.txt
@@ -4,9 +4,11 @@ SET(CMAKE_AUTORCC ON)
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(net64_qt_gui
-               main.cpp
-               mainframe.cpp
-               mainframe.hpp ../common/operator_proxy.hpp ../common/crtp.hpp)
+                main.cpp
+                mainframe.cpp
+                mainframe.hpp
+                m64p_settings_window.cpp
+                m64p_settings_window.hpp app_settings.hpp app_settings.cpp)
 
 target_link_libraries(net64_qt_gui 64coop_core)
 

--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -1,0 +1,130 @@
+//
+// Created by henrik on 07.06.19
+// Copyright 2019 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#include "app_settings.hpp"
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include "core/logging.hpp"
+
+
+namespace Frontend
+{
+
+const char* AppSettings::MAIN_CONFIG_SUB_DIR{"config/"};
+const char* AppSettings::MAIN_CONFIG_FILENAME{"config.json"};
+
+const char* AppSettings::M64P_DEFAULT_PLUGIN_DIR{"../emulator/mupen64plus/"};
+const char* AppSettings::M64P_DEFAULT_CONFIG_SUB_DIR{"config/mupen64plus/config/"};
+const char* AppSettings::M64P_DEFAULT_DATA_SUB_DIR{"config/mupen64plus/data/"};
+
+
+bool AppSettings::load(const fs::path& file)
+{
+    try
+    {
+        nlohmann::json json;
+
+        // load file
+        std::ifstream config_file(file.string());
+        if(!config_file)
+            throw std::runtime_error(fmt::format("Failed to open config file: {}", file.string()));
+
+        config_file >> json;
+
+        config_file.close();
+
+
+        auto& m64p_obj{json["mupen64plus"]};
+
+        // Helper function
+        auto load_string = [](auto& value, const auto& json_obj)
+        {
+            value = (std::string)(json_obj);
+        };
+
+        // Load last selected rom file
+        load_string(rom_file_path, json["rom_file"]);
+
+        // Load mupen64plus plugin directory
+        load_string(m64p_plugin_dir, m64p_obj["plugin_dir"]);
+
+        // Load last selected mupen64plus plugins
+        load_string(m64p_core_plugin, m64p_obj["core_plugin"]);
+        load_string(m64p_video_plugin, m64p_obj["video_plugin"]);
+        load_string(m64p_audio_plugin, m64p_obj["audio_plugin"]);
+        load_string(m64p_input_plugin, m64p_obj["input_plugin"]);
+        load_string(m64p_rsp_plugin, m64p_obj["rsp_plugin"]);
+
+    }
+    catch(const std::exception& e)
+    {
+        Core::get_logger("frontend")->warn("Failed to load config file: {}", e.what());
+        return false;
+    }
+
+    return true;
+}
+
+bool AppSettings::save(const fs::path& file)
+{
+    try
+    {
+        nlohmann::json json;
+
+        // Store currently selected rom file
+        json["rom_file"] = rom_file_path.string();
+
+        auto& m64p_obj{json["mupen64plus"]};
+
+        // Store mupen64plus plugin directory
+        m64p_obj["plugin_dir"] = m64p_plugin_dir.string();
+
+        // Store currently selected mupen64plus plugins
+        m64p_obj["video_plugin"] = m64p_video_plugin;
+        m64p_obj["audio_plugin"] = m64p_audio_plugin;
+        m64p_obj["input_plugin"] = m64p_input_plugin;
+        m64p_obj["rsp_plugin"] = m64p_rsp_plugin;
+        m64p_obj["core_plugin"] = m64p_core_plugin;
+
+
+        // Write to file
+        std::ofstream config_file(file.string());
+        if(!config_file)
+            throw std::runtime_error(fmt::format("Failed to open config file: {}", file.string()));
+
+        config_file << json.dump(4);
+    }
+    catch(const std::exception& e)
+    {
+        Core::get_logger("frontend")->warn("Failed to save config file: {}", e.what());
+        return false;
+    }
+
+    return true;
+}
+
+fs::path AppSettings::main_config_dir() const
+{
+    return appdata_path / MAIN_CONFIG_SUB_DIR;
+}
+
+fs::path AppSettings::main_config_file_path() const
+{
+    return main_config_dir() / MAIN_CONFIG_FILENAME;
+}
+
+fs::path AppSettings::m64p_config_dir() const
+{
+    return appdata_path / M64P_DEFAULT_CONFIG_SUB_DIR;
+}
+
+fs::path AppSettings::m64p_data_dir() const
+{
+    return appdata_path / M64P_DEFAULT_DATA_SUB_DIR;
+}
+
+}

--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -43,7 +43,7 @@ bool AppSettings::load(const fs::path& file)
         // Helper function
         auto load_string = [](auto& value, const auto& json_obj)
         {
-            value = json_obj.get<std::string>();
+            value = json_obj.template get<std::string>();
         };
 
         // Load last selected rom file

--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -43,7 +43,7 @@ bool AppSettings::load(const fs::path& file)
         // Helper function
         auto load_string = [](auto& value, const auto& json_obj)
         {
-            value = (std::string)(json_obj);
+            value = json_obj.get<std::string>();
         };
 
         // Load last selected rom file

--- a/src/qt_gui/app_settings.hpp
+++ b/src/qt_gui/app_settings.hpp
@@ -1,0 +1,53 @@
+//
+// Created by henrik on 07.06.19
+// Copyright 2019 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#pragma once
+
+#include <experimental/filesystem>
+
+
+namespace Frontend
+{
+
+namespace fs = std::experimental::filesystem;
+
+struct AppSettings
+{
+    // Not saved to config file:
+    fs::path appdata_path;
+
+    // Load / store functions
+    bool load(const fs::path& file);
+    bool save(const fs::path& file);
+
+
+    static const char* MAIN_CONFIG_SUB_DIR,
+                     * MAIN_CONFIG_FILENAME;
+
+    fs::path main_config_dir() const;
+    fs::path main_config_file_path() const;
+
+    fs::path rom_file_path;
+
+
+    // Mupen64Plus configuration
+    static const char* M64P_DEFAULT_PLUGIN_DIR,
+                     * M64P_DEFAULT_CONFIG_SUB_DIR,
+                     * M64P_DEFAULT_DATA_SUB_DIR;
+
+    fs::path m64p_config_dir() const;
+    fs::path m64p_data_dir() const;
+
+    fs::path m64p_plugin_dir{M64P_DEFAULT_PLUGIN_DIR};
+    std::string m64p_video_plugin,
+                m64p_audio_plugin,
+                m64p_core_plugin,
+                m64p_rsp_plugin,
+                m64p_input_plugin;
+};
+
+} // Frontend

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -86,7 +86,7 @@ void M64PSettings::refresh_plugins()
         for(const auto& entry : fs::directory_iterator(ui->folder_path_field->text().toStdString()))
         {
             auto file{QString::fromStdString(entry.path().filename().string())};
-            switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry.path()).type)
+            switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry.path().string()).type)
             {
             case M64PLUGIN_CORE:
                 ui->core_plugin_box->addItem(file);

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -1,0 +1,128 @@
+#include "m64p_settings_window.hpp"
+#include "ui_m64p_settings_window.h"
+#include <experimental/filesystem>
+#include <QDesktopServices>
+#include <QFileDialog>
+#include <QUrl>
+#include "core/emulator/m64plus.hpp"
+
+
+namespace Frontend
+{
+
+namespace fs = std::experimental::filesystem;
+
+M64PSettings::M64PSettings(QWidget* parent, AppSettings& settings)
+:QMainWindow(parent), ui(new Ui::M64PSettings), settings_{&settings}
+{
+    ui->setupUi(this);
+    ui->folder_path_field->setText(QString::fromStdString(settings_->m64p_plugin_dir.string()));
+    refresh_plugins();
+}
+
+M64PSettings::~M64PSettings()
+{
+    delete ui;
+}
+
+void Frontend::M64PSettings::on_close_pressed()
+{
+    close();
+}
+
+void M64PSettings::on_open_plugin_folder()
+{
+    QDesktopServices::openUrl(QUrl(ui->folder_path_field->text()));
+}
+
+void M64PSettings::on_set_plugin_folder()
+{
+    QFileDialog dialog{this};
+    dialog.setFileMode(QFileDialog::Directory);
+    dialog.setOption(QFileDialog::ShowDirsOnly);
+    dialog.selectUrl(QUrl(ui->folder_path_field->text()));
+
+    if(dialog.exec())
+    {
+        ui->folder_path_field->setText(dialog.selectedFiles()[0]);
+        refresh_plugins();
+    }
+}
+
+void M64PSettings::on_reset_plugin_folder()
+{
+    ui->folder_path_field->setText(QString::fromStdString(AppSettings::M64P_DEFAULT_PLUGIN_DIR));
+    refresh_plugins();
+}
+
+void M64PSettings::closeEvent(QCloseEvent*)
+{
+    auto save = [](auto& to, const QComboBox& from)
+    {
+        to = from.currentText().toStdString();
+    };
+
+    save(settings_->m64p_core_plugin, *ui->core_plugin_box);
+    save(settings_->m64p_video_plugin, *ui->video_plugin_box);
+    save(settings_->m64p_audio_plugin, *ui->audio_plugin_box);
+    save(settings_->m64p_rsp_plugin, *ui->rsp_plugin_box);
+    save(settings_->m64p_input_plugin, *ui->input_plugin_box);
+
+    settings_->m64p_plugin_dir = ui->folder_path_field->text().toStdString();
+}
+
+void M64PSettings::refresh_plugins()
+{
+    using namespace Core::Emulator::M64PTypes;
+
+    ui->audio_plugin_box->clear();
+    ui->core_plugin_box->clear();
+    ui->video_plugin_box->clear();
+    ui->input_plugin_box->clear();
+    ui->rsp_plugin_box->clear();
+
+    try
+    {
+        for(const auto& entry : fs::directory_iterator(ui->folder_path_field->text().toStdString()))
+        {
+            auto file{QString::fromStdString(entry.path().filename())};
+            switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry).type)
+            {
+            case M64PLUGIN_CORE:
+                ui->core_plugin_box->addItem(file);
+            break;
+            case M64PLUGIN_RSP:
+                ui->rsp_plugin_box->addItem(file);
+                break;
+            case M64PLUGIN_GFX:
+                ui->video_plugin_box->addItem(file);
+                break;
+            case M64PLUGIN_AUDIO:
+                ui->audio_plugin_box->addItem(file);
+                break;
+            case M64PLUGIN_INPUT:
+                ui->input_plugin_box->addItem(file);
+            default: break;
+            }
+        }
+    }
+    catch(const std::exception& e)
+    {
+        logger()->warn("Failed to load plugin folder {}: {}", ui->folder_path_field->text().toStdString(), e.what());
+    }
+
+    auto set_index_if_found = [](QComboBox& widget, const std::string& text)
+    {
+        int index{-1};
+        if((index = widget.findText(QString::fromStdString(text))) != -1)
+            widget.setCurrentIndex(index);
+    };
+
+    set_index_if_found(*ui->core_plugin_box, settings_->m64p_core_plugin);
+    set_index_if_found(*ui->audio_plugin_box, settings_->m64p_audio_plugin);
+    set_index_if_found(*ui->video_plugin_box, settings_->m64p_video_plugin);
+    set_index_if_found(*ui->input_plugin_box, settings_->m64p_input_plugin);
+    set_index_if_found(*ui->rsp_plugin_box, settings_->m64p_rsp_plugin);
+}
+
+} // Frontend

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -86,7 +86,7 @@ void M64PSettings::refresh_plugins()
         for(const auto& entry : fs::directory_iterator(ui->folder_path_field->text().toStdString()))
         {
             auto file{QString::fromStdString(entry.path().filename().string())};
-            switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry).type)
+            switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry.path()).type)
             {
             case M64PLUGIN_CORE:
                 ui->core_plugin_box->addItem(file);
@@ -108,7 +108,7 @@ void M64PSettings::refresh_plugins()
     }
     catch(const std::exception& e)
     {
-        logger()->warn("Failed to load plugin folder {}: {}", ui->folder_path_field->text().toStdString(), e.what());
+        logger()->warn("Failed to inspect plugin folder {}: {}", ui->folder_path_field->text().toStdString(), e.what());
     }
 
     auto set_index_if_found = [](QComboBox& widget, const std::string& text)

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -85,7 +85,7 @@ void M64PSettings::refresh_plugins()
     {
         for(const auto& entry : fs::directory_iterator(ui->folder_path_field->text().toStdString()))
         {
-            auto file{QString::fromStdString(entry.path().filename())};
+            auto file{QString::fromStdString(entry.path().filename().string())};
             switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry).type)
             {
             case M64PLUGIN_CORE:

--- a/src/qt_gui/m64p_settings_window.hpp
+++ b/src/qt_gui/m64p_settings_window.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QMainWindow>
+#include "core/logging.hpp"
+#include "qt_gui/app_settings.hpp"
+
+
+namespace Ui {
+class M64PSettings;
+}
+
+namespace Frontend
+{
+
+class M64PSettings : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    M64PSettings(QWidget* parent, AppSettings& settings);
+    ~M64PSettings() override;
+
+private slots:
+    void on_close_pressed();
+    void on_open_plugin_folder();
+    void on_set_plugin_folder();
+    void on_reset_plugin_folder();
+
+private:
+    void closeEvent(QCloseEvent*) override;
+    void refresh_plugins();
+
+    Ui::M64PSettings* ui;
+    AppSettings* settings_{};
+
+    CLASS_LOGGER_("frontend")
+};
+
+} // Frontend

--- a/src/qt_gui/m64p_settings_window.ui
+++ b/src/qt_gui/m64p_settings_window.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>Mupen64Plus Configuration</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/qt_gui/m64p_settings_window.ui
+++ b/src/qt_gui/m64p_settings_window.ui
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>M64PSettings</class>
+ <widget class="QMainWindow" name="M64PSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>596</width>
+    <height>467</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="tab_widget">
+      <widget class="QWidget" name="plugins_tab">
+       <attribute name="title">
+        <string>Plugins</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="folder_group_box">
+          <property name="title">
+           <string>Plugin Folder</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QPushButton" name="open_plugin_folder_btn">
+             <property name="text">
+              <string>Open</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="folder_path_field"/>
+           </item>
+           <item>
+            <widget class="QToolButton" name="set_plugin_folder_btn">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="refresh_plugins_btn">
+             <property name="text">
+              <string>Reset</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="plugin_group_box">
+          <property name="title">
+           <string>Plugins</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="core_lbl">
+             <property name="text">
+              <string>Core</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="core_plugin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="video_lbl">
+             <property name="text">
+              <string>Video</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="video_plugin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="audio_lbl">
+             <property name="text">
+              <string>Audio</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="audio_plugin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="input_lbl">
+             <property name="text">
+              <string>Input</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="input_plugin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="rsp_lbl">
+             <property name="text">
+              <string>RSP</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QComboBox" name="rsp_plugin_box">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="v_spacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>41</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="button_box">
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Close</set>
+      </property>
+      <property name="centerButtons">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>596</width>
+     <height>19</height>
+    </rect>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>M64PSettings</receiver>
+   <slot>on_close_pressed()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>490</x>
+     <y>445</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>440</x>
+     <y>388</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>open_plugin_folder_btn</sender>
+   <signal>clicked()</signal>
+   <receiver>M64PSettings</receiver>
+   <slot>on_open_plugin_folder()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>79</x>
+     <y>100</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>252</x>
+     <y>387</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>set_plugin_folder_btn</sender>
+   <signal>clicked()</signal>
+   <receiver>M64PSettings</receiver>
+   <slot>on_set_plugin_folder()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>490</x>
+     <y>98</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>56</x>
+     <y>385</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>refresh_plugins_btn</sender>
+   <signal>clicked()</signal>
+   <receiver>M64PSettings</receiver>
+   <slot>on_reset_plugin_folder()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>549</x>
+     <y>105</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>591</x>
+     <y>104</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>on_close_pressed()</slot>
+  <slot>on_open_plugin_folder()</slot>
+  <slot>on_set_plugin_folder()</slot>
+  <slot>on_reset_plugin_folder()</slot>
+ </slots>
+</ui>

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -43,16 +43,16 @@ void MainFrame::on_start_emulator()
     {// @todo
         emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
-                settings_->m64p_plugin_dir / settings_->m64p_core_plugin,
+                (settings_->m64p_plugin_dir / settings_->m64p_core_plugin).string(),
                 settings_->m64p_config_dir().string(),
                 settings_->m64p_data_dir().string()
             }
         };
 
-        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_video_plugin});
-        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_audio_plugin});
-        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_input_plugin});
-        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_rsp_plugin});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_video_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_audio_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_input_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_rsp_plugin).string()});
 
         std::ifstream rom_file(ui->lineEdit->text().toStdString(), std::ios::ate);
         if(!rom_file)

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -40,7 +40,7 @@ void MainFrame::on_start_emulator()
         return;
     }
     try
-    {// @todo
+    {
         emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
                 (settings_->m64p_plugin_dir / settings_->m64p_core_plugin).string(),

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -43,7 +43,7 @@ void MainFrame::on_start_emulator()
     {// @todo
         emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
-                fs::directory_entry(settings_->m64p_plugin_dir / settings_->m64p_core_plugin),
+                settings_->m64p_plugin_dir / settings_->m64p_core_plugin,
                 settings_->m64p_config_dir().string(),
                 settings_->m64p_data_dir().string()
             }

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -1,233 +1,84 @@
 #include "mainframe.hpp"
 #include "ui_mainframe.h"
-
-#include <QMessageBox>
 #include <fstream>
-#include <nlohmann/json.hpp>
+#include <QMessageBox>
+
 
 namespace Frontend
 {
 
 using namespace std::string_literals;
 
-
-MainFrame::MainFrame(QWidget* parent)
-:QWidget(parent), ui(new Ui::MainFrame)
+MainFrame::MainFrame(QWidget* parent, AppSettings& settings)
+:QMainWindow(parent), ui(new Ui::MainFrame), settings_{&settings}
 {
-    using namespace Core::Emulator::M64PTypes;
-    
-
     ui->setupUi(this);
 
-    ui->tbx_emu_path->setText("");
 
-    for(const auto& entry : fs::directory_iterator(M64P_PLUGIN_PATH))
-    {
-		auto path{ entry.path().string() };
-        switch(Core::Emulator::Mupen64Plus::Plugin::get_plugin_info(entry).type)
-        {
-        case M64PLUGIN_CORE:
-            ui->cbx_core_plugin->addItem(QString::fromStdString(path));
-        break;
-        case M64PLUGIN_RSP:
-            ui->cbx_rsp_plugin->addItem(QString::fromStdString(path));
-            break;
-        case M64PLUGIN_GFX:
-            ui->cbx_gfx_plugin->addItem(QString::fromStdString(path));
-            break;
-        case M64PLUGIN_AUDIO:
-            ui->cbx_audio_plugin->addItem(QString::fromStdString(path));
-            break;
-        case M64PLUGIN_INPUT:
-            ui->cbx_input_plugin->addItem(QString::fromStdString(path));
-        default: break;
-        }
-    }
-
-    load_config();
-    setWindowTitle(QCoreApplication::applicationName() + " " + QCoreApplication::applicationVersion());
+    ui->lineEdit->setText(QString::fromStdString(settings_->rom_file_path.string()));
 }
 
 MainFrame::~MainFrame()
 {
-    if(emu_.has_value())
-    {
-        emu_ = {};
-        try{emulation_thread_.get();}
-        catch(...){}
-    }
+    settings_->rom_file_path = ui->lineEdit->text().toStdString();
+
     delete ui;
 }
 
-void MainFrame::on_tbx_emu_path_returnPressed()
+void MainFrame::on_action_emulator_settings_triggered()
 {
-    on_btn_start_emu_clicked();
+    show_window(m64p_settings_win_, *settings_);
 }
 
-void MainFrame::on_btn_start_emu_clicked()
-{	
-	save_config();
-
-    if(emu_.has_value())
+void MainFrame::on_start_emulator()
+{
+    if(emulator_.has_value())
     {
-        emu_ = {};
-        try
-        {
-            emulation_thread_.get();
-        }
-        catch(const std::system_error& e)
-        {
-            QMessageBox box;
-            box.setWindowTitle("Error in " + QString::fromStdString(e.code().category().name()));
-            box.setText(QString::fromStdString("An error has occurred: "s + e.what() + "\nError code: " +
-                                               e.code().category().name() + ":"s + std::to_string(e.code().value())));
-            box.exec();
-        }
-
-        ui->btn_start_emu->setText("Start");
-
+        emulator_ = {};
+        emulation_thread_.get();
+        ui->pushButton->setText("Start");
         return;
     }
-
     try
     {
-        emu_ = Core::Emulator::Mupen64Plus{
+        emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
-                fs::directory_entry{ui->cbx_core_plugin->currentText().toStdString()},
-                fs::path{user_config_path / M64P_CONFIG_SUB_PATH}.string(),
-                fs::path{user_config_path / M64P_DATA_SUB_PATH}.string()
+                settings_->m64p_plugin_dir / settings_->m64p_core_plugin,
+                settings_->m64p_config_dir().string(),
+                settings_->m64p_data_dir().string()
             }
         };
 
-        std::ifstream rom_file{ui->tbx_emu_path->text().toStdString(), std::ios::binary | std::ios::ate};
-        if(!rom_file.is_open())
-        {
-            logger()->error("Failed to open rom");
-            emu_ = {};
-            return;
-        }
-        std::vector<char> rom_image(rom_file.tellg());
+        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_video_plugin});
+        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_audio_plugin});
+        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_input_plugin});
+        emulator_->add_plugin({emulator_->core(), settings_->m64p_plugin_dir / settings_->m64p_rsp_plugin});
+
+        std::ifstream rom_file(ui->lineEdit->text().toStdString(), std::ios::ate);
+        if(!rom_file)
+            throw std::runtime_error("Failed to open ROM file");
+
+        std::vector<std::uint8_t> rom_image(rom_file.tellg());
         rom_file.seekg(0);
-        rom_file.read(rom_image.data(), rom_image.size());
+        rom_file.read(reinterpret_cast<char*>(rom_image.data()), rom_image.size());
         rom_file.close();
 
-        emu_->load_rom(rom_image.data(), rom_image.size());
+        emulator_->load_rom(rom_image.data(), rom_image.size());
 
-		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_gfx_plugin->currentText().toStdString()}});
-		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_audio_plugin->currentText().toStdString()}});
-		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_rsp_plugin->currentText().toStdString()}});
-		emu_->add_plugin({emu_->core(), fs::directory_entry{ui->cbx_input_plugin->currentText().toStdString()}});
-
-        emulation_thread_ = std::async(std::launch::async, [this]()
+        emulation_thread_ = std::async([this]()
         {
-            emu_->execute();
+            emulator_->execute();
         });
 
-        ui->btn_start_emu->setText("Stop");
+        ui->pushButton->setText("Stop");
     }
     catch(const std::system_error& e)
     {
-        emu_ = {};
-
         QMessageBox box;
         box.setWindowTitle("Error in " + QString::fromStdString(e.code().category().name()));
         box.setText(QString::fromStdString("An error has occurred: "s + e.what() + "\nError code: " +
-                    e.code().category().name() + ":"s + std::to_string(e.code().value())));
+                                           e.code().category().name() + ":"s + std::to_string(e.code().value())));
         box.exec();
-    }
-}
-
-void MainFrame::load_config()
-{
-    using json = nlohmann::json;
-
-    std::ifstream config_file;
-    // Don't bother opening the file if it's size is zero or it doesn't exist
-    if(fs::exists(user_config_path / MAIN_CONFIG_FILE_SUB_PATH) && fs::file_size(user_config_path / MAIN_CONFIG_FILE_SUB_PATH) != 0)
-    {
-        config_file.open(user_config_path / MAIN_CONFIG_FILE_SUB_PATH);
-
-        if(config_file.good())
-        {
-            try
-            {
-                json last_save;
-
-                config_file >> last_save;
-                // messy conversion
-                ui->tbx_emu_path->setText(QString::fromStdString((std::string)last_save["rom"]));
-
-                // find index of last GFX
-                QString to_find{QString::fromStdString((std::string)last_save["gfx"])};
-                int index{ui->cbx_gfx_plugin->findText(to_find)};
-
-                // if that index was valid
-                if(index != -1)
-                {
-                    // set it as the current index
-                    ui->cbx_gfx_plugin->setCurrentIndex(index);
-                }
-
-                to_find = QString::fromStdString((std::string)last_save["audio"]);
-                index = ui->cbx_audio_plugin->findText(to_find);
-
-                if(index != -1)
-                {
-                    ui->cbx_audio_plugin->setCurrentIndex(index);
-                }
-
-                to_find = QString::fromStdString((std::string)last_save["input"]);
-                index = ui->cbx_input_plugin->findText(to_find);
-
-                if(index != -1)
-                {
-                    ui->cbx_input_plugin->setCurrentIndex(index);
-                }
-
-                to_find = QString::fromStdString((std::string)last_save["core"]);
-                index = ui->cbx_core_plugin->findText(to_find);
-
-                if(index != -1)
-                {
-                    ui->cbx_core_plugin->setCurrentIndex(index);
-                }
-
-                to_find = QString::fromStdString((std::string)last_save["rsp"]);
-                index = ui->cbx_rsp_plugin->findText(to_find);
-
-                if(index != -1)
-                {
-                    ui->cbx_rsp_plugin->setCurrentIndex(index);
-                }
-            }
-            catch(const std::exception& e)
-            {
-                logger()->warn("Exception while reading config.json");
-            }
-        }	
-    }
-}
-
-void MainFrame::save_config()
-{
-    using json = nlohmann::json;
-
-    // write values to config file
-    json config_save_data;
-    config_save_data["audio"] = ui->cbx_audio_plugin->currentText().toStdString();
-    config_save_data["gfx"] = ui->cbx_gfx_plugin->currentText().toStdString();
-    config_save_data["core"] = ui->cbx_core_plugin->currentText().toStdString();
-    config_save_data["input"] = ui->cbx_input_plugin->currentText().toStdString();
-    config_save_data["rsp"] = ui->cbx_rsp_plugin->currentText().toStdString();
-    config_save_data["rom"] = ui->tbx_emu_path->text().toStdString();
-
-    std::ofstream config_file;
-
-    config_file.open(user_config_path / MAIN_CONFIG_FILE_SUB_PATH);
-
-    if(config_file.good())
-    {
-        config_file << config_save_data.dump(4);
     }
 }
 

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -40,10 +40,10 @@ void MainFrame::on_start_emulator()
         return;
     }
     try
-    {
+    {// @todo
         emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
-                settings_->m64p_plugin_dir / settings_->m64p_core_plugin,
+                fs::directory_entry(settings_->m64p_plugin_dir / settings_->m64p_core_plugin),
                 settings_->m64p_config_dir().string(),
                 settings_->m64p_data_dir().string()
             }

--- a/src/qt_gui/mainframe.hpp
+++ b/src/qt_gui/mainframe.hpp
@@ -1,16 +1,10 @@
-#ifndef MAINFRAME_HPP
-#define MAINFRAME_HPP
+#pragma once
 
-#ifndef Q_MOC_RUN
-#include <experimental/filesystem>
 #include <future>
-#include <optional>
-#include <thread>
-#include <QStandardPaths>
-#include <QWidget>
+#include <QMainWindow>
 #include "core/emulator/m64plus.hpp"
-#include "core/logging.hpp"
-#endif
+#include "qt_gui/app_settings.hpp"
+#include "qt_gui/m64p_settings_window.hpp"
 
 
 namespace Ui {
@@ -20,39 +14,37 @@ class MainFrame;
 namespace Frontend
 {
 
-namespace fs = std::experimental::filesystem;
-
-class MainFrame : public QWidget
+struct MainFrame : QMainWindow
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
-    explicit MainFrame(QWidget* parent = nullptr);
-    ~MainFrame() override;
-
-    inline static const char* M64P_PLUGIN_PATH{"../emulator/mupen64plus/"},
-                            * M64P_CONFIG_SUB_PATH{"config/mupen64plus/config/"},
-                            * M64P_DATA_SUB_PATH{"config/mupen64plus/data/"},
-                            * MAIN_CONFIG_FILE_SUB_PATH{"config/config.json"};
-
+    explicit MainFrame(QWidget* parent, AppSettings& settings);
+    ~MainFrame();
 
 private slots:
-    void on_tbx_emu_path_returnPressed();
-    void on_btn_start_emu_clicked();
+    void on_action_emulator_settings_triggered();
+    void on_start_emulator();
 
 private:
+    template<typename T, typename... TArgs>
+    void show_window(T*& win_ptr, TArgs&&... args)
+    {
+        if(!win_ptr)
+        {
+            win_ptr = new T(this, std::forward<TArgs>(args)...);
+        }
+
+        win_ptr->show();
+        win_ptr->raise();
+        win_ptr->activateWindow();
+    }
+
     Ui::MainFrame* ui;
-    std::optional<Core::Emulator::Mupen64Plus> emu_;
+    M64PSettings* m64p_settings_win_{};
+    AppSettings* settings_;
+    std::optional<Core::Emulator::Mupen64Plus> emulator_;
     std::future<void> emulation_thread_;
-
-	void load_config();
-	void save_config();
-
-    fs::path user_config_path{QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).toStdString()};
-
-    CLASS_LOGGER_("frontend");
 };
 
 } // Frontend
-
-#endif // MAINFRAME_HPP

--- a/src/qt_gui/mainframe.hpp
+++ b/src/qt_gui/mainframe.hpp
@@ -2,9 +2,11 @@
 
 #include <future>
 #include <QMainWindow>
+#ifndef Q_MOC_RUN
 #include "core/emulator/m64plus.hpp"
 #include "qt_gui/app_settings.hpp"
 #include "qt_gui/m64p_settings_window.hpp"
+#endif
 
 
 namespace Ui {

--- a/src/qt_gui/mainframe.ui
+++ b/src/qt_gui/mainframe.ui
@@ -1,143 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainFrame</class>
- <widget class="QWidget" name="MainFrame">
+ <widget class="QMainWindow" name="MainFrame">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>523</width>
-    <height>396</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>MainWindow</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QGroupBox" name="groupBox_5">
-     <property name="title">
-      <string>Core</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_7">
-      <item>
-       <widget class="QComboBox" name="cbx_core_plugin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>GFX Plugin</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <item>
-       <widget class="QComboBox" name="cbx_gfx_plugin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="title">
-      <string>Audio Plugin</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-       <widget class="QComboBox" name="cbx_audio_plugin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Input Plugin</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <item>
-       <widget class="QComboBox" name="cbx_input_plugin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>RSP Plugin</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QComboBox" name="cbx_rsp_plugin">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="tbx_emu_path"/>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btn_start_emu">
-       <property name="text">
-        <string>Start</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-  </layout>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QLineEdit" name="lineEdit">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>200</y>
+      <width>751</width>
+      <height>22</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="pushButton">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>230</y>
+      <width>80</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Start</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>19</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuSettings">
+    <property name="title">
+     <string>Settings</string>
+    </property>
+    <addaction name="action_emulator_settings"/>
+   </widget>
+   <addaction name="menuSettings"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <action name="action_emulator_settings">
+   <property name="text">
+    <string>Emulator</string>
+   </property>
+   <property name="toolTip">
+    <string>Configure the N64 emulation</string>
+   </property>
+  </action>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>pushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>MainFrame</receiver>
+   <slot>on_start_emulator()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>386</x>
+     <y>261</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>586</x>
+     <y>517</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>on_start_emulator()</slot>
+ </slots>
 </ui>


### PR DESCRIPTION
Currently only allows to configure plugins.

Todo:
- [x] Window title
- [x] Create missing config folders on startup
- [ ] Fix minor Qt signal warnings