### PR TITLE
Store plugins and their config files in the same folder

### DIFF
--- a/src/core/emulator/m64plus.hpp
+++ b/src/core/emulator/m64plus.hpp
@@ -97,13 +97,13 @@ struct Core
     static constexpr int API_VERSION{0x020001};
 
     /// Create core from current process
-    Core(std::string root_path);
+    Core(std::string root_path, std::string data_path);
 
     /// Create core from dynamic library handle
-    Core(dynlib_t lib, std::string root_path);
+    Core(dynlib_t lib, std::string root_path, std::string data_path);
 
     /// Create core from library file
-    Core(const std::string& lib_path, std::string root_path);
+    Core(const std::string& lib_path, std::string root_path, std::string data_path);
 
     /// Non-copyable
     Core(const Core&) = delete;
@@ -173,7 +173,8 @@ private:
     }fn_{};
     PluginInfo info_;
 
-    std::string root_path_;
+    std::string root_path_,
+                data_path_;
 
     static const std::vector<std::string> FORBIDDEN_HOTKEYS;
 

--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -17,8 +17,7 @@ namespace Frontend
 const char* AppSettings::MAIN_CONFIG_SUB_DIR{"config/"};
 const char* AppSettings::MAIN_CONFIG_FILENAME{"config.json"};
 
-const char* AppSettings::M64P_DEFAULT_PLUGIN_DIR{"../emulator/mupen64plus/"};
-const char* AppSettings::M64P_DEFAULT_ROOT_DIR{"config/mupen64plus/"};
+const char* AppSettings::M64P_DEFAULT_ROOT_DIR{"mupen64plus/"};
 
 
 bool AppSettings::load(const fs::path& file)
@@ -49,7 +48,7 @@ bool AppSettings::load(const fs::path& file)
         load_string(rom_file_path, json["rom_file"]);
 
         // Load mupen64plus plugin directory
-        load_string(m64p_plugin_dir, m64p_obj["plugin_dir"]);
+        load_string(m64p_custom_pugin_dir, m64p_obj["plugin_dir"]);
 
         // Load last selected mupen64plus plugins
         load_string(m64p_core_plugin, m64p_obj["core_plugin"]);
@@ -80,7 +79,7 @@ bool AppSettings::save(const fs::path& file)
         auto& m64p_obj{json["mupen64plus"]};
 
         // Store mupen64plus plugin directory
-        m64p_obj["plugin_dir"] = m64p_plugin_dir.string();
+        m64p_obj["plugin_dir"] = m64p_custom_pugin_dir.string();
 
         // Store currently selected mupen64plus plugins
         m64p_obj["video_plugin"] = m64p_video_plugin;
@@ -119,6 +118,14 @@ fs::path AppSettings::main_config_file_path() const
 fs::path AppSettings::m64p_dir() const
 {
     return appdata_path / M64P_DEFAULT_ROOT_DIR;
+}
+
+fs::path AppSettings::m64p_plugin_dir() const
+{
+    if(m64p_custom_pugin_dir.empty())
+        return m64p_dir() / "bin";
+    else
+        return m64p_custom_pugin_dir;
 }
 
 }

--- a/src/qt_gui/app_settings.hpp
+++ b/src/qt_gui/app_settings.hpp
@@ -39,8 +39,9 @@ struct AppSettings
                      * M64P_DEFAULT_ROOT_DIR;
 
     fs::path m64p_dir() const;
+    fs::path m64p_plugin_dir() const;
 
-    fs::path m64p_plugin_dir{M64P_DEFAULT_PLUGIN_DIR};
+    fs::path m64p_custom_pugin_dir;
     std::string m64p_video_plugin,
                 m64p_audio_plugin,
                 m64p_core_plugin,

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -16,7 +16,7 @@ M64PSettings::M64PSettings(QWidget* parent, AppSettings& settings)
 :QMainWindow(parent), ui(new Ui::M64PSettings), settings_{&settings}
 {
     ui->setupUi(this);
-    ui->folder_path_field->setText(QString::fromStdString(settings_->m64p_plugin_dir.string()));
+    ui->folder_path_field->setText(QString::fromStdString(settings_->m64p_plugin_dir().string()));
     refresh_plugins();
 }
 
@@ -52,7 +52,8 @@ void M64PSettings::on_set_plugin_folder()
 
 void M64PSettings::on_reset_plugin_folder()
 {
-    ui->folder_path_field->setText(QString::fromStdString(AppSettings::M64P_DEFAULT_PLUGIN_DIR));
+    settings_->m64p_custom_pugin_dir.clear();
+    ui->folder_path_field->setText(QString::fromStdString(settings_->m64p_plugin_dir().string()));
     refresh_plugins();
 }
 
@@ -69,7 +70,7 @@ void M64PSettings::closeEvent(QCloseEvent*)
     save(settings_->m64p_rsp_plugin, *ui->rsp_plugin_box);
     save(settings_->m64p_input_plugin, *ui->input_plugin_box);
 
-    settings_->m64p_plugin_dir = ui->folder_path_field->text().toStdString();
+    settings_->m64p_custom_pugin_dir = ui->folder_path_field->text().toStdString();
 }
 
 void M64PSettings::refresh_plugins()

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -31,6 +31,7 @@ static void create_app_dirs(const AppSettings& settings)
     {
         fs::create_directories(settings.main_config_dir());
         fs::create_directories(settings.m64p_dir());
+        fs::create_directories(settings.m64p_plugin_dir());
     }
     catch(const std::exception& e)
     {

--- a/src/qt_gui/mainframe.cpp
+++ b/src/qt_gui/mainframe.cpp
@@ -44,15 +44,16 @@ void MainFrame::on_start_emulator()
     {
         emulator_ = Core::Emulator::Mupen64Plus{
             Core::Emulator::Mupen64Plus::Core{
-                (settings_->m64p_plugin_dir / settings_->m64p_core_plugin).string(),
-                settings_->m64p_dir().string()
+                (settings_->m64p_plugin_dir() / settings_->m64p_core_plugin).string(),
+                settings_->m64p_dir().string(),
+                settings_->m64p_plugin_dir().string()
             }
         };
 
-        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_video_plugin).string()});
-        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_audio_plugin).string()});
-        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_input_plugin).string()});
-        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir / settings_->m64p_rsp_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir() / settings_->m64p_video_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir() / settings_->m64p_audio_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir() / settings_->m64p_input_plugin).string()});
+        emulator_->add_plugin({emulator_->core(), (settings_->m64p_plugin_dir() / settings_->m64p_rsp_plugin).string()});
 
         std::ifstream rom_file(ui->lineEdit->text().toStdString(), std::ios::ate);
         if(!rom_file)


### PR DESCRIPTION
When downloading Mupen64Plus plugins and configuration files are in the same folder. Currently we store them in separate places. This makes the setup unnecessary complicated. That's why I changed it so that they are in the same folder. That way you can just extract the mupen64plus download into that folder.