### PR TITLE
Convert logical n64 addresses to physical ones

### DIFF
--- a/src/core/emulator/emulator.hpp
+++ b/src/core/emulator/emulator.hpp
@@ -65,8 +65,7 @@ struct IEmulator
     /// Return name of emulator
     virtual const char* name() const = 0;
 
-    static constexpr n64_usize_t RAM_SIZE{0x800000},
-                                 MAX_OFFSET{RAM_SIZE - 1};
+    static constexpr usize_t RAM_SIZE{0x800000};
 };
 
 } // Core::Emulator

--- a/src/core/memory/conversion.hpp
+++ b/src/core/memory/conversion.hpp
@@ -14,6 +14,21 @@
 namespace Core::Memory
 {
 
+constexpr n64_addr_t LOGICAL_BASE{0x80000000};
+
+
+inline n64_addr_t addr_physical_to_logical(n64_addr_t addr)
+{
+    return addr + LOGICAL_BASE;
+}
+
+inline n64_addr_t addr_logical_to_physical(n64_addr_t addr)
+{
+    assert(0x80000000 <= addr);
+
+    return addr - LOGICAL_BASE;
+}
+
 namespace Impl
 {
 template<typename T>

--- a/src/core/memory/mem_ptr.hpp
+++ b/src/core/memory/mem_ptr.hpp
@@ -9,6 +9,7 @@
 
 #include "types.hpp"
 #include "common/operator_proxy.hpp"
+#include "core/memory/conversion.hpp"
 #include "core/memory/mem_ref.hpp"
 
 
@@ -234,13 +235,16 @@ struct Ptr<N64Ptr<TType>, THandle> : PtrBase<TType, sizeof(typename THandle::add
     /// Return pointer to the address stored in the current address
     const Ptr<QualifiedType, HandleType> operator*() const
     {
-        return {this->mem_hdl_, this->mem_hdl_.template read<AddrType>(this->addr_)};
+        return {this->mem_hdl_, addr_logical_to_physical(this->mem_hdl_.template read<AddrType>(this->addr_))};
     }
 
     /// Return pointer to the address stored in the current address + index
     const Ptr<QualifiedType, HandleType> operator[](USizeType i) const
     {
-        return {this->mem_hdl_, this->mem_hdl_.template read<AddrType>(this->addr_ + Base::SIZE * i)};
+        return {
+            this->mem_hdl_,
+            addr_logical_to_physical(this->mem_hdl_.template read<AddrType>(this->addr_ + Base::SIZE * i))
+        };
     }
 
     /// Call nested pointer function
@@ -272,13 +276,16 @@ struct Ptr<N64Ptr<const TType>, THandle> : PtrBase<TType, sizeof(typename THandl
     /// Return pointer to the address stored in the current address
     const Ptr<QualifiedType, HandleType> operator*() const
     {
-        return {this->mem_hdl_, this->mem_hdl_.template read<AddrType>(this->addr_)};
+        return {this->mem_hdl_, addr_logical_to_physical(this->mem_hdl_.template read<AddrType>(this->addr_))};
     }
 
     /// Return pointer to the address stored in the current address + index
     const Ptr<QualifiedType, HandleType> operator[](USizeType i) const
     {
-        return {this->mem_hdl_, this->mem_hdl_.template read<AddrType>(this->addr_ + Base::SIZE * i)};
+        return {
+            this->mem_hdl_,
+            addr_logical_to_physical(this->mem_hdl_.template read<AddrType>(this->addr_ + Base::SIZE * i))
+        };
     }
 
     /// Call nested pointer function

--- a/src/core/memory/mem_ref.hpp
+++ b/src/core/memory/mem_ref.hpp
@@ -9,6 +9,7 @@
 
 #include "types.hpp"
 #include "common/is_instantiation.hpp"
+#include "core/memory/conversion.hpp"
 #include "core/memory/util.hpp"
 #include "core/memory/memory_handle.hpp"
 
@@ -131,8 +132,7 @@ private:
     {
         if constexpr(Common::is_instantiation_of_v<N64Ptr, T>)
         {
-
-            return Ptr<typename T::Type, HandleType>{hdl, mem_hdl_.template read<AddrType>(addr)};
+            return Ptr<typename T::Type, HandleType>{hdl, addr_logical_to_physical(mem_hdl_.template read<AddrType>(addr))};
         }
         else
         {


### PR DESCRIPTION
On the N64 RDRAM start at 0x80000000. Net64 on the other hand interprets memory addresses as offset from the base address. To keep the two compatible we have to add/subtract 0x80000000 when moving addresses to/from the n64's ram.