### PR TITLE
Set up Mupen64Plus installation on first start

### DIFF
--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -115,15 +115,25 @@ fs::path AppSettings::main_config_file_path() const
     return main_config_dir() / MAIN_CONFIG_FILENAME;
 }
 
+fs::path AppSettings::shipped_m64p_binaries_dir() const
+{
+    return fs::path("../share/mupen64plus");
+}
+
 fs::path AppSettings::m64p_dir() const
 {
     return appdata_path / M64P_DEFAULT_ROOT_DIR;
 }
 
+fs::path AppSettings::m64p_default_plugin_dir() const
+{
+    return m64p_dir() / "bin";
+}
+
 fs::path AppSettings::m64p_plugin_dir() const
 {
     if(m64p_custom_pugin_dir.empty())
-        return m64p_dir() / "bin";
+        return m64p_default_plugin_dir();
     else
         return m64p_custom_pugin_dir;
 }

--- a/src/qt_gui/app_settings.hpp
+++ b/src/qt_gui/app_settings.hpp
@@ -33,12 +33,14 @@ struct AppSettings
 
     fs::path rom_file_path;
 
-
     // Mupen64Plus configuration
     static const char* M64P_DEFAULT_PLUGIN_DIR,
                      * M64P_DEFAULT_ROOT_DIR;
 
+    fs::path shipped_m64p_binaries_dir() const;
+
     fs::path m64p_dir() const;
+    fs::path m64p_default_plugin_dir() const;
     fs::path m64p_plugin_dir() const;
 
     fs::path m64p_custom_pugin_dir;

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -25,16 +25,32 @@ using Core::LoggerPtr;
 
 namespace fs = std::experimental::filesystem;
 
-static void create_app_dirs(const AppSettings& settings)
+
+static void install_routine(AppSettings& settings)
 {
+    // Copy mupen64plus binaries
+    if(!fs::exists(settings.m64p_default_plugin_dir()) || fs::is_empty(settings.m64p_default_plugin_dir()))
+    {
+        try
+        {
+            fs::create_directories(settings.m64p_default_plugin_dir());
+            fs::copy(settings.shipped_m64p_binaries_dir(), settings.m64p_default_plugin_dir(), fs::copy_options::recursive);
+            std::cout << "Mupen64Plus bin dir missing. Copied default binaries\n";
+        }
+        catch(const std::exception& e)
+        {
+            std::cout << "Failed to copy Mupen64Plus binaries: " << e.what() << '\n';
+        }
+    }
+
+    // Create config dir
     try
     {
         fs::create_directories(settings.main_config_dir());
-        fs::create_directories(settings.m64p_plugin_dir());
     }
     catch(const std::exception& e)
     {
-        std::cout << "Failed to create application directories: " << e.what() << '\n';
+        std::cout << "Failed to create config dir: " << e.what() << '\n';
     }
 }
 
@@ -74,7 +90,7 @@ int main(int argc, char* argv[])
 
     AppSettings settings;
     settings.appdata_path = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).toStdString();
-    create_app_dirs(settings);
+    install_routine(settings);
 
     setup_logging();
 


### PR DESCRIPTION
If the mupen64plus/bin directory is nonexistent or empty, a Mupen64Plus installation bundled with the executable will be copied there on startup.