### PR TITLE
Copy Qt and Mupen64Plus binaries on installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,6 @@ endif()
 # Installation
 
 if(INSTALL_MUPEN64PLUS)
-    install(DIRECTORY ${MUPEN64PLUS_DIR}
+    install(DIRECTORY "${MUPEN64PLUS_DIR}/"
             DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/mupen64plus)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(BUILD_QT_FRONTEND)
     add_subdirectory(src/qt_gui)
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON)
-    add_subdirectory(externals/json)
+    add_subdirectory(externals/json EXCLUDE_FROM_ALL)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ include_directories(src externals)
 
 option(BUILD_CORE "Build core library" ON)
 option(BUILD_QT_FRONTEND "Build the Qt5 userinterface" ON)
+option(INSTALL_MUPEN64PLUS "Wether to include a Mupen64Plus installation with the build" OFF)
+set(MUPEN64PLUS_DIR "" CACHE PATH "The Mupen64Plus installation to include")
 
 if(BUILD_CORE)
     add_subdirectory(src/core)
@@ -34,4 +36,12 @@ if(BUILD_QT_FRONTEND)
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON)
     add_subdirectory(externals/json)
+endif()
+
+
+# Installation
+
+if(INSTALL_MUPEN64PLUS)
+    install(DIRECTORY ${MUPEN64PLUS_DIR}
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/share/mupen64plus)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(BUILD_QT_FRONTEND "Build the Qt5 userinterface" ON)
 option(INSTALL_MUPEN64PLUS "Wether to include a Mupen64Plus installation with the build" OFF)
 set(MUPEN64PLUS_DIR "" CACHE PATH "The Mupen64Plus installation to include")
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
 if(BUILD_CORE)
     add_subdirectory(src/core)
 endif()

--- a/src/qt_gui/CMakeLists.txt
+++ b/src/qt_gui/CMakeLists.txt
@@ -26,3 +26,25 @@ target_link_libraries(net64_qt_gui nlohmann_json::nlohmann_json)
 if(UNIX)
     target_link_libraries(net64_qt_gui -lpthread -lstdc++fs )
 endif()
+
+if(WIN32)
+    # Include MSVC libs
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION usr/bin)
+    set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
+    include(InstallRequiredSystemLibraries)
+    # Run windeployqt
+    get_target_property(MOC_EXECUTABLE_LOCATION Qt5::moc IMPORTED_LOCATION)
+    get_filename_component(QT_BINARY_DIRECTORY "${MOC_EXECUTABLE_LOCATION}" DIRECTORY)
+    find_program(WINDEPLOYQT_EXE windeployqt HINTS "${QT_BINARY_DIRECTORY}")
+
+    add_custom_command(TARGET net64_qt_gui POST_BUILD
+        COMMAND "${WINDEPLOYQT_EXE}" --no-translations --no-compiler-runtime "$<TARGET_FILE:net64_qt_gui>"
+        WORKING_DIRECTORY "${QT_BINARY_DIRECTORY}"
+    )
+endif()
+
+
+# Installation
+
+install(DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/usr/bin)


### PR DESCRIPTION
- Execute windeployqt.exe after build (Windows)
- Copy Mupen64Plus binaries into share/mupen64plus
- Remove json library from installation
