### PR TITLE
CMake/Windows improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,24 @@
 image: Visual Studio 2019
 
-platform:
-  - x64
- 
-configuration:
-    - Release
+environment:
+  CMAKE_PREFIX_PATH: C:\Qt\5.12.4\msvc2017\lib\cmake
 
 install:
-    - git submodule update --init --recursive
+  - git submodule update --init --recursive
+  - curl -O -L https://code.qt.io/cgit/qbs/qbs.git/plain/scripts/install-qt.sh 1>nul
+  - sh install-qt.sh --directory /c/Qt --host windows_x86 --target desktop --toolchain win32_msvc2017 --version 5.12.4 qtbase qttools qtsvg qtimageformats d3dcompiler_47 opengl32sw
 
-before_build:
-    - cmake -G "Visual Studio 16 2019" . -A x64 -DQt5_DIR="C:\Qt\5.12\msvc2017_64\lib\cmake\Qt5" -DBUILD_QT_FRONTEND=OFF
+build_script:
+  - mkdir build && cd build
+  - cmake -G "Visual Studio 16 2019" -A Win32 -DBUILD_QT_FRONTEND=ON -DINSTALL_MUPEN64PLUS=ON -DCMAKE_INSTALL_PREFIX=install ..
+  - cmake --build . --config Release
+  - cmake --install . --config Release
 
-build:
-  project: $(APPVEYOR_BUILD_FOLDER)\$(APPVEYOR_PROJECT_NAME).sln
+after_build:
+  - cd install\usr\bin
+  - xcopy /Y /S Release\* .\
+  - rmdir /S /Q Release
+
+artifacts:
+  - path: build/install
+    name: net64-coop-%APPVEYOR_REPO_COMMIT%

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# CMake build directories
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 
 if(BUILD_QT_FRONTEND)
     add_subdirectory(src/qt_gui)
+    # Make the Qt GUI the startup project for Visual Studio
+    if(MSVC_IDE)
+        set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT net64_qt_gui)
+    endif()
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON)
     add_subdirectory(externals/json EXCLUDE_FROM_ALL)

--- a/CMakeModules/CompilerWarnings.cmake
+++ b/CMakeModules/CompilerWarnings.cmake
@@ -26,7 +26,7 @@ set(GCC_WARNINGS
 set(MSVC_WARNINGS
         /permissive
         /W4
-        /W14640
+        /w14640
         /w14242
         /w14254
         /w14263

--- a/CMakeModules/ENet.cmake
+++ b/CMakeModules/ENet.cmake
@@ -12,5 +12,9 @@ add_library(enet_lib STATIC
         "${ENET_SOURCE_DIR}/unix.c"
         "${ENET_SOURCE_DIR}/win32.c")
 
+if(WIN32)
+    target_link_libraries(enet_lib PUBLIC winmm ws2_32)
+endif()
+
 target_include_directories(enet_lib PUBLIC ${ENET_INCLUDES})
 add_compile_definitions(HAS_SOCKLEN_T)


### PR DESCRIPTION
The most invasive change is to the AppVeyor configuration. I think this way makes more sense, since there is no `x64` build of Mupen64Plus in https://github.com/net64-mod/net64-mupen-builds/tree/7bf4aa8418d55ae5f4688e36b3c3a98ef0b573c2, so there would be no way to provide artifacts that would actually run.

Also since there is no Qt installed on the Visual Studio 2019 image I added Qt installation to the `install` script. See https://github.com/appveyor/ci/issues/2970 to track the issue.