### PR TITLE
Forward Mupen64Plus state callback to user

### DIFF
--- a/src/net64/emulator/emulator.hpp
+++ b/src/net64/emulator/emulator.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include "net64/logging.hpp"
 #include "types.hpp"
@@ -15,6 +16,14 @@
 namespace Net64::Emulator
 {
 
+enum struct State
+{
+    STOPPED,
+    STARTING,
+    RUNNING,
+    PAUSED
+};
+
 /// Interface for n64 emulators
 struct IEmulator
 {
@@ -22,6 +31,8 @@ struct IEmulator
     using saddr_t = n64_saddr_t;
     using usize_t = n64_usize_t;
     using ssize_t = n64_ssize_t;
+
+    using StateCallback = std::function<void(State)>;
 
     virtual ~IEmulator() = default;
 
@@ -32,7 +43,7 @@ struct IEmulator
     virtual void unload_rom() = 0;
 
     /// Execute rom, blocking
-    virtual void execute() = 0;
+    virtual void execute(const StateCallback& fn = {}) = 0;
 
     /// Stop execution
     virtual void stop() = 0;

--- a/src/net64/emulator/m64plus.hpp
+++ b/src/net64/emulator/m64plus.hpp
@@ -300,7 +300,7 @@ public:
 
     void unload_rom() override;
 
-    void execute() override;
+    void execute(const StateCallback& fn = {}) override;
 
     void stop() override;
 

--- a/src/qt_gui/mainframe.hpp
+++ b/src/qt_gui/mainframe.hpp
@@ -27,9 +27,13 @@ public:
 protected:
     void closeEvent(QCloseEvent* event) override;
 
+signals:
+    void emulator_state(Net64::Emulator::State);
+
 private slots:
     void on_action_emulator_settings_triggered();
     void on_start_emulator();
+    void on_emulator_state(Net64::Emulator::State state);
 
 private:
     template<typename T, typename... TArgs>
@@ -53,3 +57,5 @@ private:
 };
 
 } // Frontend
+
+Q_DECLARE_METATYPE(Net64::Emulator::State)


### PR DESCRIPTION
This adds an optional callback to IEmulator::execute to allow the GUI to react to emulator state changes. Also contains some auto formatting.