### PR TITLE
Search for default mupen plugin when none is set in the config file

### DIFF
--- a/src/net64/emulator/m64plus.hpp
+++ b/src/net64/emulator/m64plus.hpp
@@ -218,6 +218,9 @@ public:
     static PluginInfo get_plugin_info(const std::string& file);
     static PluginInfo get_plugin_info(dynlib_t lib);
 
+    /// Get string representation of plugin type id
+    static const char* type_str(M64PTypes::m64p_plugin_type type_id);
+
 private:
     // Function pointer types
     using plugin_startup_t = Error(CALL*)(M64PTypes::m64p_dynlib_handle, void*, void* (*)(void*, int, const char*));
@@ -235,9 +238,6 @@ private:
 
     /// Return native library handle
     dynlib_t handle();
-
-    /// Get string representation of plugin type id
-    static const char* type_str(M64PTypes::m64p_plugin_type type_id);
 
     void init_symbols();
     void init_plugin(dynlib_t core_lib);

--- a/src/qt_gui/app_settings.cpp
+++ b/src/qt_gui/app_settings.cpp
@@ -18,7 +18,14 @@ const char* AppSettings::MAIN_CONFIG_SUB_DIR{"config/"};
 const char* AppSettings::MAIN_CONFIG_FILENAME{"config.json"};
 
 const char* AppSettings::M64P_DEFAULT_ROOT_DIR{"mupen64plus/"};
-
+const char* AppSettings::M64P_DEFAULT_PLUGINS[]{
+    "",
+    "mupen64plus-rsp-hle",         ///< RSP plugin
+    "mupen64plus-video-GLideN64",  ///< GFX plugin
+    "mupen64plus-audio-sdl",       ///< Audio plugin
+    "mupen64plus-input-sdl",       ///< Input plugin
+    "mupen64plus"                  ///< Core plugin
+};
 
 bool AppSettings::load(const fs::path& file)
 {

--- a/src/qt_gui/app_settings.hpp
+++ b/src/qt_gui/app_settings.hpp
@@ -34,6 +34,7 @@ struct AppSettings
     // Mupen64Plus configuration
     static const char* M64P_DEFAULT_PLUGIN_DIR,
                      * M64P_DEFAULT_ROOT_DIR;
+    static const char* M64P_DEFAULT_PLUGINS[6];
 
     fs::path shipped_m64p_binaries_dir() const;
 


### PR DESCRIPTION
If a Mupen64Plus plugin type is not specified in the config file, this will set the config entry to a default plugin (if it exists).