### PR TITLE
Add emulator configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+
+
 language: cpp
 matrix:
   include:
     - env: NAME="linux gcc"
       os: linux
-      dist: xenial
+      dist: bionic
       compiler: gcc
       sudo: required
       addons:
@@ -11,16 +13,17 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-8
             - cmake
             - qtbase5-dev
             - qtbase5-dev-tools
+            - libsdl2-dev
       before_script:
         - mkdir build
         - cd build
-        - export CC=gcc-7
-        - export CXX=g++-7
-        - cmake .. -DCMAKE_CXX_COMPILER=g++-7 -DCMAKE_C_COMPILER=gcc-7
+        - export CC=gcc-8
+        - export CXX=g++-8
+        - cmake .. -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_C_COMPILER=gcc-8
       script:
         - make
         - make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modul
 
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-add_compile_definitions(NOMINMAX)
-include(CompilerWarnings)
+add_compile_definitions(NOMINMAX _WINSOCKAPI_ _SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING)
+include(CompilerFlags)
 
 # Generate revision information
 include(GetGitRevisionDescription)

--- a/CMakeModules/CompilerFlags.cmake
+++ b/CMakeModules/CompilerFlags.cmake
@@ -1,7 +1,4 @@
-set(GCC_WERROR "-Werror")
-set(MSVC_WERROR "/Wx")
-
-set(GCC_WARNINGS
+set(GCC_FLAGS
         -Wall
         -Wextra
         -Wno-attributes
@@ -23,9 +20,9 @@ set(GCC_WARNINGS
         #-Wsuggest-override
         -Wno-switch)
 
-set(MSVC_WARNINGS
+set(MSVC_FLAGS
         /permissive
-        /W4
+        /W3
         /w14640
         /w14242
         /w14254
@@ -45,12 +42,8 @@ set(MSVC_WARNINGS
         /w14826
         /w14928)
 
-option(ENABLE_WARNINGS "Enable warnings" ON)
-
-if(ENABLE_WARNINGS)
-    if(MSVC)
-        add_compile_options(${MSVC_WARNINGS})
-    else(MSVC)
-        add_compile_options(${GCC_WARNINGS})
-    endif(MSVC)
-endif(ENABLE_WARNINGS)
+if(MSVC)
+    set(ADDITIONAL_CXXFLAGS ${MSVC_FLAGS})
+else()
+    set(ADDITIONAL_CXXFLAGS ${GCC_FLAGS})
+endif()

--- a/CMakeModules/SDL2_finder.cmake
+++ b/CMakeModules/SDL2_finder.cmake
@@ -1,0 +1,29 @@
+if(WIN32)
+    include(FetchContent)
+    FetchContent_Declare(
+            sdl2_bin_win32
+            URL "https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip")
+endif()
+
+function(requires_sdl2)
+    find_package(SDL2)
+    if(NOT SDL_FOUND)
+        if(WIN32)
+            # Download SDL2 binaries
+            include(FetchContent)
+            FetchContent_Declare(
+                    sdl2_bin_win32
+                    URL "https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip")
+            FetchContent_GetProperties(sdl2_bin_win32)
+            if(NOT ${sdl2_bin_win32_POPULATED})
+                FetchContent_Populate(sdl2_bin_win32)
+            endif()
+            # Manually set paths
+            message("Using downloaded SDL2 win32 binaries")
+            set(SDL2_INCLUDE_DIR "${sdl2_bin_win32_SOURCE_DIR}/include")
+            set(SDL2_LIBRARY_RELEASE "${sdl2_bin_win32_SOURCE_DIR}/lib/x86/SDL2.lib")
+            set(SDL2main_LIBRARIES "${sdl2_bin_win32_SOURCE_DIR}/lib/x86/SDL2main.lib")
+        endif()
+    endif()
+    find_package(SDL2 REQUIRED)
+endfunction()

--- a/externals/cmake-modules/FindSDL2.cmake
+++ b/externals/cmake-modules/FindSDL2.cmake
@@ -1,0 +1,130 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2.
+
+This module defines the following IMPORTED targets:
+- SDL2::Core — Libraries should link against this.
+- SDL2::SDL2 — Applications should link against this instead of SDL2::Core.
+
+This module defines the following variables:
+- SDL2_FOUND
+- SDL2main_FOUND
+- SDL2_VERSION_STRING
+- SDL2_LIBRARIES (deprecated)
+- SDL2_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Look for SDL2.
+find_path(SDL2_INCLUDE_DIR SDL.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_PATH}
+)
+
+if (NOT SDL2_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_LIBRARY_RELEASE
+        NAMES SDL2 SDL-2.0
+        PATH_SUFFIXES lib ${_SDL2_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_LIBRARY_DEBUG
+        NAMES SDL2d
+        PATH_SUFFIXES lib ${_SDL2_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for SDL2main.
+    find_library(SDL2main_LIBRARIES
+        NAMES SDL2main
+        PATH_SUFFIXES lib ${_SDL2_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2)
+endif()
+
+# Find the SDL2 version.
+if(SDL2_INCLUDE_DIR AND EXISTS "${SDL2_INCLUDE_DIR}/SDL_version.h")
+    file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_MAJOR "${SDL2_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_MINOR "${SDL2_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_PATCH "${SDL2_VERSION_PATCH_LINE}")
+    set(SDL2_VERSION_STRING ${SDL2_VERSION_MAJOR}.${SDL2_VERSION_MINOR}.${SDL2_VERSION_PATCH})
+    unset(SDL2_VERSION_MAJOR_LINE)
+    unset(SDL2_VERSION_MINOR_LINE)
+    unset(SDL2_VERSION_PATCH_LINE)
+    unset(SDL2_VERSION_MAJOR)
+    unset(SDL2_VERSION_MINOR)
+    unset(SDL2_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2
+    REQUIRED_VARS SDL2_LIBRARIES SDL2_INCLUDE_DIR
+    VERSION_VAR SDL2_VERSION_STRING)
+
+find_package_handle_standard_args(SDL2main
+    REQUIRED_VARS SDL2main_LIBRARIES SDL2_INCLUDE_DIR
+    VERSION_VAR SDL2_VERSION_STRING)
+
+if(SDL2_FOUND)
+    set(SDL2_LIBRARIES ${SDL2_LIBRARY})
+    set(SDL2_INCLUDE_DIR ${SDL2_INCLUDE_DIR})
+
+    # Define the core SDL2 target.
+    if(NOT TARGET SDL2::Core)
+        add_library(SDL2::Core UNKNOWN IMPORTED)
+        set_target_properties(SDL2::Core PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIR})
+
+        # Link against Cocoa on macOS.
+        if(APPLE)
+            set_property(TARGET SDL2::Core APPEND PROPERTY
+              INTERFACE_LINK_OPTIONS -framework Cocoa)
+        endif()
+
+        if(SDL2_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::Core APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::Core PROPERTIES
+                IMPORTED_LOCATION_RELEASE ${SDL2_LIBRARY_RELEASE})
+        endif()
+
+        if(SDL2_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Core APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::Core PROPERTIES
+                IMPORTED_LOCATION_DEBUG ${SDL2_LIBRARY_DEBUG})
+        endif()
+
+        if(NOT SDL2_LIBRARY_RELEASE AND NOT SDL2_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Core APPEND PROPERTY
+                IMPORTED_LOCATION ${SDL2_LIBRARY})
+        endif()
+    endif()
+
+    # Define the SDL2 target.
+    if(NOT TARGET SDL2::SDL2)
+        add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+        set_target_properties(SDL2::SDL2 PROPERTIES
+            INTERFACE_LINK_LIBRARIES SDL2::Core
+            IMPORTED_LOCATION ${SDL2main_LIBRARIES})
+    endif()
+endif()

--- a/externals/cmake-modules/FindSDL2_LICENSE.md
+++ b/externals/cmake-modules/FindSDL2_LICENSE.md
@@ -1,0 +1,15 @@
+Copyright © 2019 [Sandro Stikić](mailto:sandro@stikic.me)
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all
+copies.
+
+**The software is provided "as is" and the author disclaims all
+warranties with regard to this software including all implied
+warranties of merchantability and fitness. In no event shall the
+author be liable for any special, direct, indirect, or consequential
+damages or any damages whatsoever resulting from loss of use, data or
+profits, whether in an action of contract, negligence or other
+tortious action, arising out of or in connection with the use or
+performance of this software.**

--- a/externals/cmake-modules/FindSDL2_gfx.cmake
+++ b/externals/cmake-modules/FindSDL2_gfx.cmake
@@ -1,0 +1,110 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2_gfx.
+
+This module defines the following IMPORTED targets:
+- SDL2::Gfx — Link against this.
+
+This module defines the following variables:
+- SDL2_GFX_FOUND
+- SDL2_GFX_VERSION_STRING
+- SDL2_GFX_LIBRARIES (deprecated)
+- SDL2_GFX_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Ensure SDL2 is installed.
+find_package(SDL2 REQUIRED QUIET)
+
+if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "SDL2 not found")
+endif()
+
+# Look for SDL2_gfx.
+find_path(SDL2_GFX_INCLUDE_DIR SDL2_gfxPrimitives.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_GFX_PATH}
+)
+
+if (NOT SDL2_GFX_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_GFX_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_GFX_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_GFX_LIBRARY_RELEASE
+        NAMES SDL2_gfx
+        PATH_SUFFIXES lib ${_SDL2_GFX_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_GFX_LIBRARY_DEBUG
+        NAMES SDL2_gfxd
+        PATH_SUFFIXES lib ${_SDL2_GFX_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2_GFX)
+endif()
+
+# Find the SDL2_gfx version.
+if(SDL2_GFX_INCLUDE_DIR AND EXISTS "${SDL2_GFX_INCLUDE_DIR}/SDL2_gfxPrimitives.h")
+    file(STRINGS "${SDL2_GFX_INCLUDE_DIR}/SDL2_gfxPrimitives.h" SDL2_GFX_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL2_GFXPRIMITIVES_MAJOR[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_GFX_INCLUDE_DIR}/SDL2_gfxPrimitives.h" SDL2_GFX_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL2_GFXPRIMITIVES_MINOR[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_GFX_INCLUDE_DIR}/SDL2_gfxPrimitives.h" SDL2_GFX_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL2_GFXPRIMITIVES_MICRO[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL2_GFXPRIMITIVES_MAJOR[ \t]+([0-9]+)$" "\\1" SDL2_GFX_VERSION_MAJOR "${SDL2_GFX_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL2_GFXPRIMITIVES_MINOR[ \t]+([0-9]+)$" "\\1" SDL2_GFX_VERSION_MINOR "${SDL2_GFX_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL2_GFXPRIMITIVES_MICRO[ \t]+([0-9]+)$" "\\1" SDL2_GFX_VERSION_PATCH "${SDL2_GFX_VERSION_PATCH_LINE}")
+    set(SDL2_GFX_VERSION_STRING ${SDL2_GFX_VERSION_MAJOR}.${SDL2_GFX_VERSION_MINOR}.${SDL2_GFX_VERSION_PATCH})
+    unset(SDL2_GFX_VERSION_MAJOR_LINE)
+    unset(SDL2_GFX_VERSION_MINOR_LINE)
+    unset(SDL2_GFX_VERSION_PATCH_LINE)
+    unset(SDL2_GFX_VERSION_MAJOR)
+    unset(SDL2_GFX_VERSION_MINOR)
+    unset(SDL2_GFX_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_gfx
+    REQUIRED_VARS SDL2_GFX_LIBRARIES SDL2_GFX_INCLUDE_DIR
+    VERSION_VAR SDL2_GFX_VERSION_STRING)
+
+if(SDL2_GFX_FOUND)
+    set(SDL2_GFX_LIBRARIES ${SDL2_GFX_LIBRARY})
+    set(SDL2_GFX_INCLUDE_DIR ${SDL2_GFX_INCLUDE_DIR})
+
+    # Define the SDL2_gfx target.
+    if(NOT TARGET SDL2::Gfx)
+        add_library(SDL2::Gfx UNKNOWN IMPORTED)
+        set_target_properties(SDL2::Gfx PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${SDL2_GFX_INCLUDE_DIR})
+
+        if(SDL2_GFX_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::Gfx APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::Gfx PROPERTIES
+                IMPORTED_LOCATION_RELEASE ${SDL2_GFX_LIBRARY_RELEASE})
+        endif()
+
+        if(SDL2_GFX_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Gfx APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::Gfx PROPERTIES
+                IMPORTED_LOCATION_DEBUG ${SDL2_GFX_LIBRARY_DEBUG})
+        endif()
+
+        if(NOT SDL2_GFX_LIBRARY_RELEASE AND NOT SDL2_GFX_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Gfx APPEND PROPERTY
+                IMPORTED_LOCATION ${SDL2_GFX_LIBRARY})
+        endif()
+    endif()
+endif()

--- a/externals/cmake-modules/FindSDL2_image.cmake
+++ b/externals/cmake-modules/FindSDL2_image.cmake
@@ -1,0 +1,110 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2_image.
+
+This module defines the following IMPORTED targets:
+- SDL2::Image — Link against this.
+
+This module defines the following variables:
+- SDL2_IMAGE_FOUND
+- SDL2_IMAGE_VERSION_STRING
+- SDL2_IMAGE_LIBRARIES (deprecated)
+- SDL2_IMAGE_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Ensure SDL2 is installed.
+find_package(SDL2 REQUIRED QUIET)
+
+if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "SDL2 not found")
+endif()
+
+# Look for SDL2_image.
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_IMAGE_PATH}
+)
+
+if (NOT SDL2_IMAGE_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_IMAGE_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_IMAGE_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_IMAGE_LIBRARY_RELEASE
+        NAMES SDL2_image
+        PATH_SUFFIXES lib ${_SDL2_IMAGE_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_IMAGE_LIBRARY_DEBUG
+        NAMES SDL2_imaged
+        PATH_SUFFIXES lib ${_SDL2_IMAGE_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2_IMAGE)
+endif()
+
+# Find the SDL2_image version.
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+    set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+    unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+    unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+    unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+    unset(SDL2_IMAGE_VERSION_MAJOR)
+    unset(SDL2_IMAGE_VERSION_MINOR)
+    unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_image
+    REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIR
+    VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+if(SDL2_IMAGE_FOUND)
+    set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+    set(SDL2_IMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIR})
+
+    # Define the SDL2_image target.
+    if(NOT TARGET SDL2::Image)
+        add_library(SDL2::Image UNKNOWN IMPORTED)
+        set_target_properties(SDL2::Image PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${SDL2_IMAGE_INCLUDE_DIR}")
+
+        if(SDL2_IMAGE_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::Image APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::Image PROPERTIES
+                IMPORTED_LOCATION_RELEASE "${SDL2_IMAGE_LIBRARY_RELEASE}")
+        endif()
+
+        if(SDL2_IMAGE_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Image APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::Image PROPERTIES
+                IMPORTED_LOCATION_DEBUG "${SDL2_IMAGE_LIBRARY_DEBUG}")
+        endif()
+
+        if(NOT SDL2_IMAGE_LIBRARY_RELEASE AND NOT SDL2_IMAGE_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Image APPEND PROPERTY
+                IMPORTED_LOCATION "${SDL2_IMAGE_LIBRARY}")
+        endif()
+    endif()
+endif()

--- a/externals/cmake-modules/FindSDL2_mixer.cmake
+++ b/externals/cmake-modules/FindSDL2_mixer.cmake
@@ -1,0 +1,110 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2_mixer.
+
+This module defines the following IMPORTED targets:
+- SDL2::Mixer — Link against this.
+
+This module defines the following variables:
+- SDL2_MIXER_FOUND
+- SDL2_MIXER_VERSION_STRING
+- SDL2_MIXER_LIBRARIES (deprecated)
+- SDL2_MIXER_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Ensure SDL2 is installed.
+find_package(SDL2 REQUIRED QUIET)
+
+if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "SDL2 not found")
+endif()
+
+# Look for SDL2_mixer.
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_MIXER_PATH}
+)
+
+if (NOT SDL2_MIXER_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_MIXER_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_MIXER_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_MIXER_LIBRARY_RELEASE
+        NAMES SDL2_mixer
+        PATH_SUFFIXES lib ${_SDL2_MIXER_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_MIXER_LIBRARY_DEBUG
+        NAMES SDL2_mixerd
+        PATH_SUFFIXES lib ${_SDL2_MIXER_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2_MIXER)
+endif()
+
+# Find the SDL2_mixer version.
+if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MAJOR "${SDL2_MIXER_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MINOR "${SDL2_MIXER_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_PATCH "${SDL2_MIXER_VERSION_PATCH_LINE}")
+    set(SDL2_MIXER_VERSION_STRING ${SDL2_MIXER_VERSION_MAJOR}.${SDL2_MIXER_VERSION_MINOR}.${SDL2_MIXER_VERSION_PATCH})
+    unset(SDL2_MIXER_VERSION_MAJOR_LINE)
+    unset(SDL2_MIXER_VERSION_MINOR_LINE)
+    unset(SDL2_MIXER_VERSION_PATCH_LINE)
+    unset(SDL2_MIXER_VERSION_MAJOR)
+    unset(SDL2_MIXER_VERSION_MINOR)
+    unset(SDL2_MIXER_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_mixer
+    REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIR
+    VERSION_VAR SDL2_MIXER_VERSION_STRING)
+
+if(SDL2_MIXER_FOUND)
+    set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+    set(SDL2_MIXER_INCLUDE_DIR ${SDL2_MIXER_INCLUDE_DIR})
+
+    # Define the SDL2_mixer target.
+    if(NOT TARGET SDL2::Mixer)
+        add_library(SDL2::Mixer UNKNOWN IMPORTED)
+        set_target_properties(SDL2::Mixer PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${SDL2_MIXER_INCLUDE_DIR})
+
+        if(SDL2_MIXER_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::Mixer APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::Mixer PROPERTIES
+                IMPORTED_LOCATION_RELEASE ${SDL2_MIXER_LIBRARY_RELEASE})
+        endif()
+
+        if(SDL2_MIXER_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Mixer APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::Mixer PROPERTIES
+                IMPORTED_LOCATION_DEBUG ${SDL2_MIXER_LIBRARY_DEBUG})
+        endif()
+
+        if(NOT SDL2_MIXER_LIBRARY_RELEASE AND NOT SDL2_MIXER_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Mixer APPEND PROPERTY
+                IMPORTED_LOCATION ${SDL2_MIXER_LIBRARY})
+        endif()
+    endif()
+endif()

--- a/externals/cmake-modules/FindSDL2_net.cmake
+++ b/externals/cmake-modules/FindSDL2_net.cmake
@@ -1,0 +1,110 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2_net.
+
+This module defines the following IMPORTED targets:
+- SDL2::Net — Link against this.
+
+This module defines the following variables:
+- SDL2_NET_FOUND
+- SDL2_NET_VERSION_STRING
+- SDL2_NET_LIBRARIES (deprecated)
+- SDL2_NET_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Ensure SDL2 is installed.
+find_package(SDL2 REQUIRED QUIET)
+
+if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "SDL2 not found")
+endif()
+
+# Look for SDL2_net.
+find_path(SDL2_NET_INCLUDE_DIR SDL_net.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_NET_PATH}
+)
+
+if (NOT SDL2_NET_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_NET_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_NET_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_NET_LIBRARY_RELEASE
+        NAMES SDL2_net
+        PATH_SUFFIXES lib ${_SDL2_NET_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_NET_LIBRARY_DEBUG
+        NAMES SDL2_netd
+        PATH_SUFFIXES lib ${_SDL2_NET_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2_NET)
+endif()
+
+# Find the SDL2_net version.
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+    file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_MAJOR "${SDL2_NET_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_MINOR "${SDL2_NET_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_PATCH "${SDL2_NET_VERSION_PATCH_LINE}")
+    set(SDL2_NET_VERSION_STRING ${SDL2_NET_VERSION_MAJOR}.${SDL2_NET_VERSION_MINOR}.${SDL2_NET_VERSION_PATCH})
+    unset(SDL2_NET_VERSION_MAJOR_LINE)
+    unset(SDL2_NET_VERSION_MINOR_LINE)
+    unset(SDL2_NET_VERSION_PATCH_LINE)
+    unset(SDL2_NET_VERSION_MAJOR)
+    unset(SDL2_NET_VERSION_MINOR)
+    unset(SDL2_NET_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_net
+    REQUIRED_VARS SDL2_NET_LIBRARIES SDL2_NET_INCLUDE_DIR
+    VERSION_VAR SDL2_NET_VERSION_STRING)
+
+if(SDL2_NET_FOUND)
+    set(SDL2_NET_LIBRARIES ${SDL2_NET_LIBRARY})
+    set(SDL2_NET_INCLUDE_DIR ${SDL2_NET_INCLUDE_DIR})
+
+    # Define the SDL2_net target.
+    if(NOT TARGET SDL2::Net)
+        add_library(SDL2::Net UNKNOWN IMPORTED)
+        set_target_properties(SDL2::Net PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${SDL2_NET_INCLUDE_DIR})
+
+        if(SDL2_NET_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::Net APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::Net PROPERTIES
+                IMPORTED_LOCATION_RELEASE ${SDL2_NET_LIBRARY_RELEASE})
+        endif()
+
+        if(SDL2_NET_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Net APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::Net PROPERTIES
+                IMPORTED_LOCATION_DEBUG ${SDL2_NET_LIBRARY_DEBUG})
+        endif()
+
+        if(NOT SDL2_NET_LIBRARY_RELEASE AND NOT SDL2_NET_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::Net APPEND PROPERTY
+                IMPORTED_LOCATION ${SDL2_NET_LIBRARY})
+        endif()
+    endif()
+endif()

--- a/externals/cmake-modules/FindSDL2_ttf.cmake
+++ b/externals/cmake-modules/FindSDL2_ttf.cmake
@@ -1,0 +1,110 @@
+# Licensed under the ISC license. Please see the LICENSE.md file for details.
+# Copyright (c) 2019 Sandro Stikić <https://github.com/opeik>
+
+#[[============================================================================
+FindSDL2
+---------
+
+Try to find SDL2_ttf.
+
+This module defines the following IMPORTED targets:
+- SDL2::TTF — Link against this.
+
+This module defines the following variables:
+- SDL2_TTF_FOUND
+- SDL2_TTF_VERSION_STRING
+- SDL2_TTF_LIBRARIES (deprecated)
+- SDL2_TTF_INCLUDE_DIRS (deprecated)
+#============================================================================]]
+
+# Ensure SDL2 is installed.
+find_package(SDL2 REQUIRED QUIET)
+
+if(NOT SDL2_FOUND)
+    message(FATAL_ERROR "SDL2 not found")
+endif()
+
+# Look for SDL2_ttf.
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+    PATH_SUFFIXES SDL2 include/SDL2 include
+    PATHS ${SDL2_TTF_PATH}
+)
+
+if (NOT SDL2_TTF_LIBRARIES)
+    # Determine architecture.
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_SDL2_TTF_PATH_SUFFIX lib/x64)
+    else()
+        set(_SDL2_TTF_PATH_SUFFIX lib/x86)
+    endif()
+
+    # Look for the release version of SDL2.
+    find_library(SDL2_TTF_LIBRARY_RELEASE
+        NAMES SDL2_ttf
+        PATH_SUFFIXES lib ${_SDL2_TTF_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    # Look for the debug version of SDL2.
+    find_library(SDL2_TTF_LIBRARY_DEBUG
+        NAMES SDL2_ttfd
+        PATH_SUFFIXES lib ${_SDL2_TTF_PATH_SUFFIX}
+        PATHS ${SDL2_PATH}
+    )
+
+    include(SelectLibraryConfigurations)
+    select_library_configurations(SDL2_TTF)
+endif()
+
+# Find the SDL2_ttf version.
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MAJOR "${SDL2_TTF_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MINOR "${SDL2_TTF_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_PATCH "${SDL2_TTF_VERSION_PATCH_LINE}")
+    set(SDL2_TTF_VERSION_STRING ${SDL2_TTF_VERSION_MAJOR}.${SDL2_TTF_VERSION_MINOR}.${SDL2_TTF_VERSION_PATCH})
+    unset(SDL2_TTF_VERSION_MAJOR_LINE)
+    unset(SDL2_TTF_VERSION_MINOR_LINE)
+    unset(SDL2_TTF_VERSION_PATCH_LINE)
+    unset(SDL2_TTF_VERSION_MAJOR)
+    unset(SDL2_TTF_VERSION_MINOR)
+    unset(SDL2_TTF_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2_ttf
+    REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIR
+    VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+if(SDL2_TTF_FOUND)
+    set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+    set(SDL2_TTF_INCLUDE_DIR ${SDL2_TTF_INCLUDE_DIR})
+
+    # Define the SDL2_ttf target.
+    if(NOT TARGET SDL2::TTF)
+        add_library(SDL2::TTF UNKNOWN IMPORTED)
+        set_target_properties(SDL2::TTF PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${SDL2_TTF_INCLUDE_DIR})
+
+        if(SDL2_TTF_LIBRARY_RELEASE)
+            set_property(TARGET SDL2::TTF APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS RELEASE)
+            set_target_properties(SDL2::TTF PROPERTIES
+                IMPORTED_LOCATION_RELEASE ${SDL2_TTF_LIBRARY_RELEASE})
+        endif()
+
+        if(SDL2_TTF_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::TTF APPEND PROPERTY
+                IMPORTED_CONFIGURATIONS DEBUG)
+            set_target_properties(SDL2::TTF PROPERTIES
+                IMPORTED_LOCATION_DEBUG ${SDL2_TTF_LIBRARY_DEBUG})
+        endif()
+
+        if(NOT SDL2_TTF_LIBRARY_RELEASE AND NOT SDL2_TTF_LIBRARY_DEBUG)
+            set_property(TARGET SDL2::TTF APPEND PROPERTY
+                IMPORTED_LOCATION ${SDL2_TTF_LIBRARY})
+        endif()
+    endif()
+endif()

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,5 +1,6 @@
-﻿---
+---
 BasedOnStyle: Microsoft
+AccessModifierOffset: -4
 AlignEscapedNewlines: Left
 AllowAllConstructorInitializersOnNextLine: 'true'
 AllowShortCaseLabelsOnASingleLine: 'false'
@@ -53,11 +54,11 @@ Standard: Auto
 TabWidth: '4'
 UseTab: Never
 IncludeCategories:
-  - Regex:           '^<.*\.h>|^<.*\.hpp>|^<.*\.hh>|^<.*\.hxx>'
-    Priority:        2
-  - Regex:           '^<.*'
-    Priority:        0
-  - Regex:           '.*'
-    Priority:        5
 
+  - Regex:           '^\<[^Q][^/.>]*\>'
+    Priority:        -2
+  - Regex:           '^\<'
+    Priority:        -1
+  - Regex:           '^\"'
+    Priority:        0
 ...

--- a/src/common/sdl_event_handler.cpp
+++ b/src/common/sdl_event_handler.cpp
@@ -1,0 +1,63 @@
+//
+// Created by henrik on 28.04.20.
+// Copyright 2020 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#include "sdl_event_handler.hpp"
+
+
+SDL_EventHandler::SDL_EventHandler()
+{
+    register_obj(*this);
+}
+
+SDL_EventHandler::~SDL_EventHandler()
+{
+    unregister_obj(*this);
+}
+
+void SDL_EventHandler::poll_events()
+{
+    SDL_Event event{};
+    while(SDL_PollEvent(&event))
+    {
+        dispatch_event(event);
+    }
+}
+
+void SDL_EventHandler::register_obj(SDL_EventHandler& obj)
+{
+    std::scoped_lock g(list_mutex_s);
+
+    if(first_handler_s)
+    {
+        first_handler_s->prev_handler = &obj;
+        obj.next_handler = first_handler_s;
+    }
+    first_handler_s = &obj;
+}
+
+void SDL_EventHandler::unregister_obj(SDL_EventHandler& obj)
+{
+    std::scoped_lock g(list_mutex_s);
+
+    if(obj.prev_handler)
+        obj.prev_handler->next_handler = obj.next_handler;
+    if(obj.next_handler)
+        obj.next_handler->prev_handler = obj.prev_handler;
+}
+
+void SDL_EventHandler::dispatch_event(const SDL_Event& event)
+{
+    std::unique_lock g(list_mutex_s);
+
+    auto next_handler{first_handler_s};
+
+    while(next_handler)
+    {
+        next_handler->handle_sdl_event(event);
+        next_handler = next_handler->next_handler;
+    }
+}

--- a/src/common/sdl_event_handler.hpp
+++ b/src/common/sdl_event_handler.hpp
@@ -1,0 +1,36 @@
+//
+// Created by henrik on 28.04.20.
+// Copyright 2020 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#pragma once
+
+#include <mutex>
+#include <SDL_events.h>
+
+
+struct SDL_EventHandler
+{
+    SDL_EventHandler();
+
+    virtual ~SDL_EventHandler();
+
+    static void poll_events();
+
+protected:
+    virtual void handle_sdl_event(const SDL_Event&){}
+
+private:
+    static void register_obj(SDL_EventHandler& obj);
+    static void unregister_obj(SDL_EventHandler& obj);
+
+    static void dispatch_event(const SDL_Event& event);
+
+    SDL_EventHandler* prev_handler{};
+    SDL_EventHandler* next_handler{};
+
+    inline static SDL_EventHandler* first_handler_s{};
+    inline static std::mutex list_mutex_s;
+};

--- a/src/common/sdl_event_handler.hpp
+++ b/src/common/sdl_event_handler.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <mutex>
+
 #include <SDL_events.h>
 
 
@@ -20,7 +21,7 @@ struct SDL_EventHandler
     static void poll_events();
 
 protected:
-    virtual void handle_sdl_event(const SDL_Event&){}
+    virtual void handle_sdl_event(const SDL_Event&) {}
 
 private:
     static void register_obj(SDL_EventHandler& obj);

--- a/src/net64/CMakeLists.txt
+++ b/src/net64/CMakeLists.txt
@@ -39,11 +39,24 @@ add_library(net64_core STATIC
         net/protocol.cpp
         net64.cpp
         net64.hpp
-        ../install_dir.cpp)
+        ../install_dir.cpp
+        emulator/m64plus_core.hpp
+        emulator/m64plus_plugin.hpp
+        emulator/m64plus_config.hpp
+        emulator/m64plus_config.cpp
+        emulator/m64plus_error.hpp
+        emulator/m64plus_error.cpp
+        )
+
+target_compile_options(net64_core PRIVATE ${ADDITIONAL_CXXFLAGS})
 
 include(ENet)
 include_directories(${ENET_INCLUDES})
 target_link_libraries(net64_core enet_lib)
+
+include(SDL2_finder)
+requires_sdl2()
+target_link_libraries(net64_core SDL2::Core)
 
 if(UNIX)
     target_link_libraries(net64_core -ldl)

--- a/src/net64/emulator/emulator.hpp
+++ b/src/net64/emulator/emulator.hpp
@@ -8,7 +8,11 @@
 #pragma once
 
 #include <functional>
+#include <memory>
+#include <optional>
 #include <string>
+#include <SDL_joystick.h>
+#include <SDL_keycode.h>
 #include "net64/logging.hpp"
 #include "types.hpp"
 
@@ -24,6 +28,10 @@ enum struct State
     STOPPED
 };
 
+struct IAudioSettings;
+struct IVideoSettings;
+struct IControllerSettings;
+
 /// Interface for n64 emulators
 struct IEmulator
 {
@@ -38,14 +46,30 @@ struct IEmulator
 
     virtual ~IEmulator() = default;
 
+    /// Get audio settings object
+    virtual std::unique_ptr<IAudioSettings> audio_settings()
+    {
+        return nullptr;
+    }
+
+    /// Get video settings object
+    virtual std::unique_ptr<IVideoSettings> video_settings()
+    {
+        return nullptr;
+    }
+
+    /// Get controller settings object for controller [controller 0 - 3]
+    virtual std::unique_ptr<IControllerSettings> controller_settings(unsigned short controller)
+    {
+        (void)controller;
+        return nullptr;
+    }
+
     /// Load uncompressed rom image
     virtual void load_rom(void* rom_data, std::size_t n) = 0;
 
     /// Unload rom
     virtual void unload_rom() = 0;
-
-    /// Execute rom, blocking
-    //virtual void execute(const StateCallback& fn = {}) = 0;
 
     /// Start emulation
     virtual void start(const StateCallback& fn = {}) = 0;
@@ -85,6 +109,313 @@ struct IEmulator
     virtual const char* name() const = 0;
 
     static constexpr usize_t RAM_SIZE{0x800000};
+};
+
+struct IAudioSettings
+{
+    virtual ~IAudioSettings() = default;
+
+    /**
+     * Reads current emulator volume
+     * @param vol Volume (0.0 - 1.0)
+     * @return true if reading volume is supported, false otherwise
+     */
+    virtual bool get_volume(float& vol) = 0;
+
+    /**
+     * Sets emulator volume
+     * @param vol Volume (0.0 - 1.0)
+     * @return true if setting volume is supported, false otherwise
+     */
+    virtual bool set_volume(float vol) = 0;
+};
+
+struct IVideoSettings
+{
+    virtual ~IVideoSettings() = default;
+
+    /**
+     * Reads current fullscreen setting
+     * @param fullscreen true if fullscreen enabled
+     * @return true if reading fullscreen setting is supported
+     */
+    virtual bool get_fullscreen(bool& fullscreen) = 0;
+
+    /**
+     * Reads current emulator screen dimensions
+     * @param width Current width
+     * @param height Current height
+     * @return true if reading screen diemensions is supported
+     */
+    virtual bool get_dimensions(unsigned& width, unsigned& height) = 0;
+
+    /**
+     * Reads current vsync setting
+     * @param vsync true if vsync enabled
+     * @return true if reading vsync setting is supported
+     */
+    virtual bool get_vsync(bool& vsync) = 0;
+
+    /**
+     * Enables/disables fullscreen
+     * @param fullscreen
+     * @return true if setting fullscreen setting is supported
+     */
+    virtual bool set_fullscreen(bool fullscreen) = 0;
+
+    /**
+     * Set emulator screen dimensions
+     * @param width
+     * @param height
+     * @return true if setting emulator screen dimensions is supported
+     */
+    virtual bool set_dimensions(unsigned width, unsigned height) = 0;
+
+    /**
+     * Set vsync setting
+     * @param vsync
+     * @return true if setting vsync setting is supported
+     */
+    virtual bool set_vsync(bool vsync) = 0;
+};
+
+struct IControllerSettings
+{
+    struct sdl_input_t
+    {
+        enum struct Type
+        {
+            NONE,
+            KEY,
+            MOUSE_BUTTON,
+            JOY_BUTTON,
+            JOY_AXIS,
+            JOY_HAT,
+            JOY_BALL
+        }type;
+
+        union
+        {
+            struct
+            {
+                int index;
+                int value;
+            }joy;
+            SDL_Keycode key_code;
+            unsigned mouse_button;
+        };
+    };
+
+    /// Specifies which type of expansion pak is in the controller
+    enum struct ControllerPak
+    {
+        NONE = 1,
+        MEM_PAK = 2,
+        RUMBLE_PAK = 3
+    };
+
+    /// Controller configuration mode
+    enum struct ConfigurationMode
+    {
+        MANUAL = 0,
+        AUTO_NAMED_SDL_DEV = 1,
+        AUTOMATIC = 2
+    };
+
+    enum struct N64Button
+    {
+        A,
+        B,
+        Z,
+        L,
+        R,
+        START,
+        D_UP,
+        D_DOWN,
+        D_LEFT,
+        D_RIGHT,
+        C_UP,
+        C_DOWN,
+        C_LEFT,
+        C_RIGHT,
+        ANALOG_UP,
+        ANALOG_DOWN,
+        ANALOG_LEFT,
+        ANALOG_RIGHT,
+
+        NUM_BUTTONS
+    };
+
+
+    virtual ~IControllerSettings() = default;
+
+    static std::optional<ControllerPak> pak_from_string(const std::string& str)
+    {
+        if(str == pak_to_string(ControllerPak::NONE))
+            return ControllerPak::NONE;
+        if(str == pak_to_string(ControllerPak::MEM_PAK))
+            return ControllerPak::MEM_PAK;
+        if(str == pak_to_string(ControllerPak::RUMBLE_PAK))
+            return ControllerPak::RUMBLE_PAK;
+        return {};
+    }
+
+    static std::optional<ConfigurationMode> config_mode_from_string(const std::string& str)
+    {
+        if(str == config_mode_to_string(ConfigurationMode::AUTOMATIC))
+            return ConfigurationMode::AUTOMATIC;
+        if(str == config_mode_to_string(ConfigurationMode::MANUAL))
+            return ConfigurationMode::MANUAL;
+        if(str == config_mode_to_string(ConfigurationMode::AUTO_NAMED_SDL_DEV))
+            return ConfigurationMode::AUTO_NAMED_SDL_DEV;
+        return {};
+    }
+
+    static const char* config_mode_to_string(ConfigurationMode mode)
+    {
+        switch(mode)
+        {
+        case ConfigurationMode::AUTOMATIC:
+            return "Automatic";
+        case ConfigurationMode::MANUAL:
+            return "Manual";
+        case ConfigurationMode::AUTO_NAMED_SDL_DEV:
+            return "Auto with named SDL device";
+        }
+        assert(false);
+        return nullptr;
+    }
+
+    static const char* pak_to_string(ControllerPak pak)
+    {
+        switch(pak)
+        {
+        case ControllerPak::NONE:
+            return "None";
+        case ControllerPak::MEM_PAK:
+            return "Memory pak";
+        case ControllerPak::RUMBLE_PAK:
+            return "Rumble pak";
+        }
+        assert(false);
+        return nullptr;
+    }
+
+    /**
+     * Reads current device bound to this n64 controller
+     * @param device SDL device name or "Keyboard"
+     * @param device_index SDL joystick device index or -1 for keyboard or -2 for none
+     * @return true if reading device is supported
+     */
+    virtual bool get_device(std::string& device, int& device_index) = 0;
+
+    /**
+     * Reads currently plugged in expansion pak
+     * @param pak The expansion pak type that is plugged in
+     * @return true if reading expansion pak is supported
+     */
+    virtual bool get_pak(ControllerPak& pak) = 0;
+
+    /**
+     * Reads configuration mode
+     * @param mode Currently used configuration mode
+     * @return true if reading configuration mode is supported
+     */
+    virtual bool get_config_mode(ConfigurationMode& mode) = 0;
+
+    /**
+     * Reads if the virtual n64 controller is plugged in
+     * @param plugged true if plugged in
+     * @return true if reading plugged in status is supported
+     */
+    virtual bool get_plugged(bool& plugged) = 0;
+
+    /**
+     * Reads if the mouse is used as input method for this n64 controller
+     * @param mouse_enabled true if enabled
+     * @return true if reading mouse enabled status is supported
+     */
+    virtual bool get_mouse_enabled(bool& mouse_enabled) = 0;
+
+    /**
+     * Reads the current analog deadzone
+     * @param deadzone current deadzone (0.0 - 1.0)
+     * @return true if reading deadzone is supported
+     */
+    virtual bool get_analog_deadzone(float& deadzone) = 0;
+
+    /**
+     * Reads the current analog peak value
+     * @param peak current peak (0.0 - 1.0)
+     * @return true if reading analog peak is supported
+     */
+    virtual bool get_analog_peak(float& peak) = 0;
+
+    /**
+     * Reads the current SDL thing bound to this n64 button
+     * @param btn N64 button
+     * @param sdl_input sdl input used for this virtual n64 button
+     * @return true if reading this binding is supported
+     */
+    virtual bool get_bind(N64Button btn, sdl_input_t& sdl_input) = 0;
+
+    /**
+     * Sets the SDL device bound to this n64 controller
+     * @param device SDL device name or "Keyboard"
+     * @param device_index SDL joystick device_index or -1 for keyboard or -2 for none
+     * @return true if setting the device is supported
+     */
+    virtual bool set_device(const std::string& device, int device_index) = 0;
+
+    /**
+     * Sets the expansion pak plugged into this controller
+     * @param pak Expansion pak to plug in
+     * @return true if setting the expansion pak is supported
+     */
+    virtual bool set_pak(ControllerPak pak) = 0;
+
+    /**
+     * Sets the configuration mode
+     * @param mode configuration mode
+     * @return true if setting the configuration mode is supported
+     */
+    virtual bool set_config_mode(ConfigurationMode mode) = 0;
+
+    /**
+     * Enables / disables this virtual controller
+     * @param plugged Wether this controller is plugged in
+     * @return true if enabling / disabling this controller is supported
+     */
+    virtual bool set_plugged(bool plugged) = 0;
+
+    /**
+     * Enables / disables the mouse as input mode for this controller
+     * @param mouse_enabled Wether to enable the mouse for this controller
+     * @return true if enabling / disabling the mouse for this controller is supported
+     */
+    virtual bool set_mouse_enabled(bool mouse_enabled) = 0;
+
+    /**
+     * Sets the deadzone of the analog stick
+     * @param deadzone deadzone of analog stick (0.0 - 1.0)
+     * @return
+     */
+    virtual bool set_analog_deadzone(float deadzone) = 0;
+
+    /**
+     * Sets the peak of the analog stick
+     * @param peak peak of the analog stick (0.0 - 1.0)
+     * @return
+     */
+    virtual bool set_analog_peak(float peak) = 0;
+
+    /**
+     * Binds a button to the virtual n64 button
+     * @param btn N64 button to set
+     * @param sdl_input Input used for this virtual n64 button
+     * @return true if binding this n64 button is supported
+     */
+    virtual bool set_bind(N64Button btn, sdl_input_t sdl_input) = 0;
 };
 
 } // Net64::Emulator

--- a/src/net64/emulator/emulator.hpp
+++ b/src/net64/emulator/emulator.hpp
@@ -11,15 +11,16 @@
 #include <memory>
 #include <optional>
 #include <string>
+
 #include <SDL_joystick.h>
 #include <SDL_keycode.h>
+
 #include "net64/logging.hpp"
 #include "types.hpp"
 
 
 namespace Net64::Emulator
 {
-
 enum struct State
 {
     RUNNING,
@@ -47,16 +48,10 @@ struct IEmulator
     virtual ~IEmulator() = default;
 
     /// Get audio settings object
-    virtual std::unique_ptr<IAudioSettings> audio_settings()
-    {
-        return nullptr;
-    }
+    virtual std::unique_ptr<IAudioSettings> audio_settings() { return nullptr; }
 
     /// Get video settings object
-    virtual std::unique_ptr<IVideoSettings> video_settings()
-    {
-        return nullptr;
-    }
+    virtual std::unique_ptr<IVideoSettings> video_settings() { return nullptr; }
 
     /// Get controller settings object for controller [controller 0 - 3]
     virtual std::unique_ptr<IControllerSettings> controller_settings(unsigned short controller)
@@ -192,15 +187,14 @@ struct IControllerSettings
             JOY_AXIS,
             JOY_HAT,
             JOY_BALL
-        }type;
+        } type;
 
-        union
-        {
+        union {
             struct
             {
                 int index;
                 int value;
-            }joy;
+            } joy;
             SDL_Keycode key_code;
             unsigned mouse_button;
         };
@@ -418,4 +412,4 @@ struct IControllerSettings
     virtual bool set_bind(N64Button btn, sdl_input_t sdl_input) = 0;
 };
 
-} // Net64::Emulator
+} // namespace Net64::Emulator

--- a/src/net64/emulator/m64plus.cpp
+++ b/src/net64/emulator/m64plus.cpp
@@ -8,7 +8,7 @@
 #include "m64plus.hpp"
 
 #include <algorithm>
-#include <cmath>
+#include <SDL_joystick.h>
 #include <net64/error_codes.hpp>
 #include "net64/memory/util.hpp"
 
@@ -24,13 +24,917 @@ bool failed(Mupen64Plus::Error err)
     return err != Mupen64Plus::Error::SUCCESS;
 }
 
+const std::array<const char*, 7> FORBIDDEN_HOTKEYS{
+    "Kbd Mapping Load State", "Kbd Mapping Speed Down",
+    "Kbd Mapping Speed Up", "Kbd Mapping Pause",
+    "Kbd Mapping Fast Forward", "Kbd Mapping Frame Advance",
+    "Kbd Mapping Gameshark"
+};
+
 }
 
-Mupen64Plus::Mupen64Plus(const std::string& lib_path, std::string root_path, std::string data_path)
-:core_{lib_path, std::move(root_path), std::move(data_path)}
+struct Mupen64PlusAudioSettings : IAudioSettings
 {
-    assert(!has_instance);
-    has_instance = true;
+    explicit Mupen64PlusAudioSettings(M64PlusHelper::Core& core):
+        core_(&core)
+    {}
+
+    bool get_volume(float& vol) override
+    {
+        try
+        {
+            auto config{core_->config()};
+
+            auto section{config.open_section("Audio-SDL")};
+
+            vol = static_cast<float>(section.get_int("VOLUME_DEFAULT")) / 100;
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_volume(float vol) override
+    {
+        // @todo: Adjust volume in realtime with AudioPlugin::VolumeSetLevel(int)
+
+        float tmp{};
+        if(!get_volume(tmp))
+            return false;
+
+        try
+        {
+            auto config{core_->config()};
+
+            auto section{config.open_section("Audio-SDL")};
+
+            section.set("VOLUME_DEFAULT", static_cast<int>(vol * 100));
+
+            config.save("Audio-SDL");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+private:
+    M64PlusHelper::Core* core_;
+};
+
+struct Mupen64PlusVideoSettings : IVideoSettings
+{
+    explicit Mupen64PlusVideoSettings(M64PlusHelper::Core& core):
+        core_(&core)
+    {}
+
+    bool get_fullscreen(bool& fullscreen) override
+    {
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            fullscreen = section.get_bool("Fullscreen");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_dimensions(unsigned& width, unsigned& height) override
+    {
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            width = static_cast<unsigned>(section.get_int("ScreenWidth"));
+            height = static_cast<unsigned>(section.get_int("ScreenHeight"));
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_vsync(bool& vsync) override
+    {
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            vsync = section.get_bool("VerticalSync");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_fullscreen(bool fullscreen) override
+    {
+        bool tmp{};
+        if(!get_fullscreen(tmp))
+            return false;
+
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            section.set("Fullscreen", fullscreen);
+
+            core_->config().save("Video-General");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_dimensions(unsigned width, unsigned height) override
+    {
+        unsigned tmp1{}, tmp2{};
+        if(!get_dimensions(tmp1, tmp2))
+            return false;
+
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            section.set("ScreenWidth", (int)width);
+            section.set("ScreenHeight", (int)height);
+
+            core_->config().save("Video-General");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_vsync(bool vsync) override
+    {
+        bool tmp{};
+        if(!get_vsync(tmp))
+            return false;
+
+        try
+        {
+            auto section{core_->config().open_section("Video-General")};
+
+            section.set("VerticalSync", vsync);
+
+            core_->config().save("Video-General");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+private:
+    M64PlusHelper::Core* core_;
+};
+
+struct Mupen64PlusControllerSettings : IControllerSettings
+{
+    explicit Mupen64PlusControllerSettings(M64PlusHelper::Core& core, unsigned short joy_index):
+        core_{&core}, joy_index_{joy_index}
+    {}
+
+    bool get_device(std::string& device, int& device_index) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            device = section.get_string("name");
+            device_index = section.get_int("device");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_pak(ControllerPak& pak) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            switch(section.get_int("plugin"))
+            {
+            case 1:
+                pak = ControllerPak::NONE;
+                break;
+            case 2:
+                pak = ControllerPak::MEM_PAK;
+                break;
+            case 5:
+                pak = ControllerPak::RUMBLE_PAK;
+                break;
+            default:
+                return false;
+            }
+        }
+        catch(const std::system_error& e)
+        {
+            get_logger("mupen64plus")->error(e.what());
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_config_mode(ConfigurationMode& mode) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            switch(section.get_int("mode"))
+            {
+            case 0:
+                mode = ConfigurationMode::MANUAL;
+                break;
+            case 1:
+                mode = ConfigurationMode::AUTO_NAMED_SDL_DEV;
+                break;
+            case 2:
+                mode = ConfigurationMode::AUTOMATIC;
+                break;
+            default:
+                return false;
+            }
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_plugged(bool& plugged) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            plugged = section.get_bool("plugged");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_mouse_enabled(bool& mouse_enabled) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            mouse_enabled = section.get_bool("mouse");
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_analog_deadzone(float& deadzone) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            auto[x, y]{parse_analog_xy(section.get_string("AnalogDeadzone"))};
+
+            // Ignore the  y deadzone
+            (void)y;
+            deadzone = static_cast<float>(x) / static_cast<float>(std::numeric_limits<std::int16_t>::max());
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_analog_peak(float& peak) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            auto[x, y]{parse_analog_xy(section.get_string("AnalogPeak"))};
+
+            // Ignore the  y peak
+            (void)y;
+
+            peak = static_cast<float>(x) / static_cast<float>(std::numeric_limits<std::uint16_t>::max() / 2);
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool get_bind(N64Button btn, sdl_input_t& sdl_input) override
+    {
+        try
+        {
+            auto section{open_section()};
+
+            sdl_input = get_button(section, btn);
+        }
+        catch(...)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_device(const std::string& device, int device_index) override
+    {
+        std::string tmp1;
+        int tmp2{};
+        if(!get_device(tmp1, tmp2))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            if(device_index == -1 || device == "Keyboard")
+            {
+                // Keyboard
+                section.set("name", "Keyboard");
+                section.set("device", -1);
+            }
+            else
+            {
+                section.set("name", device.c_str());
+                section.set("device", device_index);
+            }
+
+            save();
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_pak(ControllerPak pak) override
+    {
+        ControllerPak tmp{};
+        if(!get_pak(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            switch(pak)
+            {
+            case ControllerPak::NONE:
+                section.set("plugin", 1);
+                break;
+            case ControllerPak::MEM_PAK:
+                section.set("plugin", 2);
+                break;
+            case ControllerPak::RUMBLE_PAK:
+                section.set("plugin", 5);
+                break;
+            default:
+                return false;
+            }
+
+            save();
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_config_mode(ConfigurationMode mode) override
+    {
+        ConfigurationMode tmp{};
+        if(!get_config_mode(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            switch(mode)
+            {
+            case ConfigurationMode::MANUAL:
+                section.set("mode", 0);
+                break;
+            case ConfigurationMode::AUTO_NAMED_SDL_DEV:
+                section.set("mode", 1);
+                break;
+            case ConfigurationMode::AUTOMATIC:
+                section.set("mode", 2);
+                break;
+            default:
+                return false;
+            }
+
+            save();
+        }
+        catch(const std::system_error& e)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_plugged(bool plugged) override
+    {
+        bool tmp{};
+        if(!get_plugged(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            section.set("plugged", plugged);
+
+            save();
+        }
+        catch(const std::system_error&)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_mouse_enabled(bool mouse_enabled) override
+    {
+        bool tmp{};
+        if(!get_mouse_enabled(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            section.set("mouse", mouse_enabled);
+
+            save();
+        }
+        catch(const std::system_error&)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_analog_deadzone(float deadzone) override
+    {
+        float tmp{};
+        if(!get_analog_deadzone(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            auto absolute_deadzone{std::to_string(static_cast<unsigned>(deadzone * std::numeric_limits<std::int16_t>::max()))};
+
+            section.set("AnalogDeadzone", std::string(absolute_deadzone + ',' + absolute_deadzone).c_str());
+
+            save();
+        }
+        catch(const std::system_error&)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_analog_peak(float peak) override
+    {
+        float tmp{};
+        if(!get_analog_peak(tmp))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            auto absolute_peak{std::to_string(static_cast<unsigned>(peak * (std::numeric_limits<std::uint16_t>::max() / 2)))};
+
+            section.set("AnalogPeak", std::string(absolute_peak + ',' + absolute_peak).c_str());
+
+            save();
+        }
+        catch(const std::system_error&)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool set_bind(N64Button btn, sdl_input_t sdl_input) override
+    {
+        N64Button tmp1{};
+        sdl_input_t tmp2{};
+        if(!get_bind(tmp1, tmp2))
+            return false;
+
+        try
+        {
+            auto section{open_section()};
+
+            set_button(section, btn, sdl_input);
+
+            save();
+        }
+        catch(const std::system_error&)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+private:
+    M64PlusHelper::ConfigSection open_section()
+    {
+        return core_->config().open_section(
+            std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str()
+        );
+    }
+
+    void save()
+    {
+        core_->config().save(std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str());
+    }
+
+    static std::string format_analog_xy(std::int16_t x, std::int16_t y)
+    {
+        return std::to_string(x) + ',' + std::to_string(y);
+    }
+
+    static std::pair<std::int16_t, std::int16_t> parse_analog_xy(const std::string& str)
+    {
+        auto c{str.find(',')};
+
+        if(c == std::string::npos)
+            throw std::system_error(make_error_code(std::errc::invalid_argument));
+
+        try
+        {
+            auto xy{std::make_pair<unsigned long , unsigned long>(std::stoul(str), std::stoul(str.c_str() + c + 1))};
+            std::pair<std::int16_t, std::int16_t> ret(
+                std::clamp(xy.first, 0ul, (unsigned long)std::numeric_limits<std::int16_t>::max()),
+                std::clamp(xy.second, 0ul, (unsigned long)std::numeric_limits<std::int16_t>::max())
+            );
+
+            return ret;
+        }
+        catch(...)
+        {
+            throw std::system_error(make_error_code(std::errc::invalid_argument));
+        }
+    }
+
+    static const char* n64_button_str(N64Button btn)
+    {
+        return btn_enum2str_s[static_cast<unsigned>(btn)];
+    }
+
+    static std::pair<sdl_input_t, sdl_input_t> parse_sdl_input(const std::string& str)
+    {
+        std::pair<sdl_input_t, sdl_input_t> input;
+        input.first.type = sdl_input_t::Type::NONE;
+        input.second.type = input.first.type;
+
+        if(str.empty())
+            return input;
+
+        /// Splits string at ',' & ' '
+        auto get_args{[](std::string_view str) -> std::vector<std::string>
+        {
+            std::vector<std::string> args;
+
+            auto begin{str.find_first_of('(') + 1};
+
+            if(begin == std::string::npos || begin == str.size() - 1)
+                return args;
+
+            str.remove_prefix(begin);
+
+            while(!str.empty())
+            {
+                auto arg_begin{str.find_first_not_of(", ")};
+                if(arg_begin == std::string::npos)
+                    break;
+                str.remove_prefix(arg_begin);
+                auto arg_end{str.find_first_of(", )")};
+                if(arg_end == std::string::npos || arg_end == 0)
+                    break;
+                args.emplace_back(str, 0, arg_end);
+                str.remove_prefix(arg_end);
+            }
+
+            return args;
+        }};
+
+        auto begin{std::string::npos};
+        auto args{get_args(str)};
+
+        if(args.empty())
+            return input;
+
+        if((begin = str.find("key(")) != std::string::npos)
+        {
+            input.first.type = sdl_input_t::Type::KEY;
+            input.first.key_code = std::stoi(args[0]);
+
+            if(args.size() > 1)
+            {
+                input.second.key_code = std::stoi(args[1]);
+                input.second.type = input.first.type;
+            }
+        }
+        else if((begin = str.find("button(")) != std::string::npos)
+        {
+            input.first.type = sdl_input_t::Type::JOY_BUTTON;
+            input.first.joy.index = std::stoi(args[0]);
+
+            if(args.size() > 1)
+            {
+                input.second.joy.index = std::stoi(args[1]);
+                input.second.type = input.first.type;
+            }
+        }
+        else if((begin = str.find("axis(")) != std::string::npos)
+        {
+            input.first.type = sdl_input_t::Type::JOY_AXIS;
+            input.first.joy.index = std::stoi(args[0]);
+            input.first.joy.value = (args[0].back() == '+' ? 1 : -1);
+            
+            if(args.size() > 1)
+            {
+                input.second.type = input.first.type;
+                input.second.joy.index = std::stoi(args[1]);
+                input.second.joy.value = (args[1].back() == '+' ? 1 : -1);
+            }
+        }
+        else if((begin = str.find("hat(")) != std::string::npos)
+        {
+            auto parse_dir = [](std::string_view str, int& c)
+            {
+                if(str == "Up")
+                    c = SDL_HAT_UP;
+                else if(str == "Down")
+                    c = SDL_HAT_DOWN;
+                else if(str == "Left")
+                    c = SDL_HAT_LEFT;
+                else if(str == "Right")
+                    c = SDL_HAT_RIGHT;
+                else
+                    return false;
+                return true;
+            };
+
+            input.first.type = sdl_input_t::Type::JOY_HAT;
+            input.first.joy.index = std::stoi(args[0]);
+            if(!parse_dir(args[1], input.first.joy.value))
+                throw std::runtime_error("Invalid joyhat direction");
+
+            if(args.size() > 2)
+            {
+                input.second.type = input.first.type;
+                input.second.joy.index = input.first.joy.index;
+                if(!parse_dir(args[2], input.second.joy.value))
+                    throw std::runtime_error("Invalid joyhat direction");
+            }
+        }
+        else if((begin = str.find("mouse(")) != std::string::npos)
+        {
+            input.first.type = sdl_input_t::Type::MOUSE_BUTTON;
+            input.first.mouse_button = (unsigned)std::stoul(args[0]);
+        }
+
+        return input;
+    }
+
+    static std::string sdl_hat_direction(int joy_value)
+    {
+        if(joy_value == SDL_HAT_UP)
+            return "Up";
+        if(joy_value == SDL_HAT_DOWN)
+            return "Down";
+        if(joy_value == SDL_HAT_LEFT)
+            return "Left";
+        if(joy_value == SDL_HAT_RIGHT)
+            return "Right";
+        else
+            throw std::system_error(make_error_code(std::errc::invalid_argument));
+    }
+
+    static void set_button(M64PlusHelper::ConfigSection section, N64Button n64_button, sdl_input_t input)
+    {
+        // Special treatment for analog stick
+        if(n64_button == N64Button::ANALOG_DOWN  ||
+           n64_button == N64Button::ANALOG_UP ||
+           n64_button == N64Button::ANALOG_LEFT ||
+           n64_button == N64Button::ANALOG_RIGHT)
+        {
+            auto set{[&section](N64Button n64_button, const std::string& str)
+            {
+                section.set(n64_button_str(n64_button), str.c_str());
+            }};
+
+            auto get_pair{[&section, input, n64_button]() -> std::pair<sdl_input_t, sdl_input_t>
+            {
+                N64Button first{n64_button}, second{};
+
+                switch(n64_button)
+                {
+                case N64Button::ANALOG_RIGHT:
+                    second = N64Button::ANALOG_LEFT;
+                    break;
+                case N64Button::ANALOG_LEFT:
+                    second = N64Button::ANALOG_RIGHT;
+                    break;
+                case N64Button::ANALOG_UP:
+                    second = N64Button::ANALOG_DOWN;
+                    break;
+                case N64Button::ANALOG_DOWN:
+                    second = N64Button::ANALOG_UP;
+                    break;
+                }
+
+                auto opposite_bind{get_button(section, second)};
+
+                bool swap{};
+                if(first == N64Button::ANALOG_RIGHT || first == N64Button::ANALOG_DOWN)
+                    swap = true;
+
+                // Mupen64Plus doesn't support binding two different input types to the same axis (or two different hats)
+                if(opposite_bind.type != input.type ||
+                   (input.type == sdl_input_t::Type::JOY_HAT && input.joy.index != opposite_bind.joy.index))
+                {
+                    opposite_bind.type = sdl_input_t::Type::NONE;
+                }
+
+                if(swap)
+                    return {opposite_bind, input};
+
+                return {input, opposite_bind};
+            }};
+
+
+            auto[first, second]{get_pair()};
+
+            switch(input.type != sdl_input_t::Type::NONE ? input.type : second.type)
+            {
+            case sdl_input_t::Type::KEY:
+                set(n64_button, "key(" +
+                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.key_code)) + ',' +
+                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.key_code)) + ")");
+                break;
+            case sdl_input_t::Type::JOY_AXIS:
+                set(n64_button, "axis(" +
+                    (first.type == sdl_input_t::Type::NONE ? "" :
+                        std::to_string(first.joy.index) + (first.joy.value < 0 ? "-" : "+")) + std::string(",") +
+                    (second.type == sdl_input_t::Type::NONE ? "" :
+                        std::to_string(second.joy.index) + (second.joy.value < 0 ? "-" : "+")) + std::string(")"));
+                break;
+            case sdl_input_t::Type::JOY_BUTTON:
+                set(n64_button, "button(" +
+                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.joy.index)) + ',' +
+                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.joy.index)) + ")");
+                break;
+            case sdl_input_t::Type::JOY_HAT:
+                set(n64_button, "hat(" +
+                    (first.type == sdl_input_t::Type::NONE ? std::to_string(second.joy.index) + " " + sdl_hat_direction(second.joy.value) :
+                        std::to_string(first.joy.index) + " " + sdl_hat_direction(first.joy.value)) +
+                    (second.type == sdl_input_t::Type::NONE ? "" :
+                        " " + sdl_hat_direction(second.joy.value)) + ")");
+                break;
+            case sdl_input_t::Type::MOUSE_BUTTON:
+                set(n64_button, "mouse(" +
+                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.mouse_button)) + ',' +
+                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.mouse_button)) + ")");
+                break;
+            case sdl_input_t::Type::NONE:
+                set(n64_button, "");
+                break;
+            }
+        }
+        else
+        {
+            if(input.type == sdl_input_t::Type::NONE)
+            {
+                section.set(n64_button_str(n64_button), "");
+                return;
+            }
+
+            auto set{[&section](N64Button n64_button, const std::string& str)
+            {
+                section.set(n64_button_str(n64_button), str.c_str());
+            }};
+
+            switch(input.type)
+            {
+            case sdl_input_t::Type::KEY:
+                set(n64_button, "key(" + std::to_string(input.key_code) + ")");
+                break;
+            case sdl_input_t::Type::JOY_AXIS:
+                set(n64_button, "axis(" + std::to_string(input.joy.index) +
+                    (input.joy.value < 0 ? "-" : "+") +
+                    std::string(",9830)")); // We'll use a default analog to digital trigger of 30%
+                break;
+            case sdl_input_t::Type::JOY_BUTTON:
+                set(n64_button, "button(" + std::to_string(input.joy.index) + ")");
+                break;
+            case sdl_input_t::Type::JOY_HAT:
+                set(n64_button, "hat(" + std::to_string(input.joy.index) + ' ' + sdl_hat_direction(input.joy.value) + ")");
+                break;
+            case sdl_input_t::Type::MOUSE_BUTTON:
+                set(n64_button, "mouse(" + std::to_string(input.mouse_button) + ")");
+                break;
+            }
+        }
+    }
+
+    static sdl_input_t get_button(M64PlusHelper::ConfigSection section, N64Button n64_button)
+    {
+        auto inputs{parse_sdl_input(section.get_string(n64_button_str(n64_button)))};
+
+        if(n64_button == N64Button::ANALOG_DOWN || n64_button == N64Button::ANALOG_RIGHT)
+            return inputs.second;
+        else
+            return inputs.first;
+    }
+
+    M64PlusHelper::Core* core_;
+    unsigned short joy_index_;
+
+    inline static const std::array<const char*, static_cast<unsigned>(N64Button::NUM_BUTTONS)> btn_enum2str_s{
+            "A Button", "B Button", "Z Trig", "L Trig", "R Trig",
+            "Start", "DPad U", "DPad D", "DPad L", "DPad R",
+            "C Button U", "C Button D", "C Button L", "C Button R",
+            "Y Axis", "Y Axis",
+            "X Axis", "X Axis"
+    };
+};
+
+
+Mupen64Plus::Mupen64Plus(const std::string& lib_path, std::string root_path, std::string data_path):
+    core_{lib_path, root_path, std::move(data_path)},
+    emulator_root_{std::move(root_path)}
+{
+    assert(!has_instance_s);
+    has_instance_s = true;
 }
 
 Mupen64Plus::~Mupen64Plus()
@@ -43,7 +947,23 @@ Mupen64Plus::~Mupen64Plus()
         if(rom_loaded_)
             unload_rom();
     }
-    has_instance = false;
+    has_instance_s = false;
+}
+
+std::unique_ptr<IAudioSettings> Mupen64Plus::audio_settings()
+{
+    return std::make_unique<Mupen64PlusAudioSettings>(core_);
+}
+
+std::unique_ptr<IVideoSettings> Mupen64Plus::video_settings()
+{
+    return std::make_unique<Mupen64PlusVideoSettings>(core_);
+}
+
+std::unique_ptr<IControllerSettings> Mupen64Plus::controller_settings(unsigned short controller)
+{
+    assert(controller < 4);
+    return std::make_unique<Mupen64PlusControllerSettings>(core_, controller);
 }
 
 void Mupen64Plus::add_plugin(const std::string& lib_path)
@@ -51,11 +971,14 @@ void Mupen64Plus::add_plugin(const std::string& lib_path)
     std::lock_guard g(mutex_);
     assert(state_ == MupenState::Stopped);
 
+    // Unload the previous plugin
+    plugins_[Plugin::get_plugin_info(lib_path).type].reset();
+
     auto plugin = new Plugin(core_, lib_path);
     plugins_[plugin->info().type] = std::unique_ptr<Plugin>(plugin);
 }
 
-void Mupen64Plus::remove_plugin(M64PTypes::m64p_plugin_type type)
+void Mupen64Plus::remove_plugin(m64p_plugin_type type)
 {
     std::lock_guard g(mutex_);
     assert(state_ == MupenState::Stopped);
@@ -68,7 +991,9 @@ void Mupen64Plus::load_rom(void* rom_data, std::size_t n)
     std::lock_guard g(mutex_);
     assert(!rom_loaded_);
 
-    auto ret {core_.do_cmd(M64PTypes::M64CMD_ROM_OPEN, static_cast<int>(n), rom_data)};
+    prepare_config();
+
+    auto ret {core_.do_cmd(M64CMD_ROM_OPEN, static_cast<int>(n), rom_data)};
     if(failed(ret))
     {
         std::system_error err(make_error_code(ret), "Failed to load ROM image");
@@ -86,7 +1011,7 @@ void Mupen64Plus::unload_rom()
 
     rom_loaded_ = false;
 
-    auto ret{core_.do_cmd(M64PTypes::M64CMD_ROM_CLOSE, 0, nullptr)};
+    auto ret{core_.do_cmd(M64CMD_ROM_CLOSE, 0, nullptr)};
     if(failed(ret))
     {
         auto errc{make_error_code(ret)};
@@ -129,7 +1054,6 @@ void Mupen64Plus::start(const StateCallback& fn)
     {
         try
         {
-            core_.prepare_config_file();
             attach_plugins();
         }
         catch(...)
@@ -139,14 +1063,14 @@ void Mupen64Plus::start(const StateCallback& fn)
             throw;
         }
 
-        core_.set_state_callback([this, &notify](M64PTypes::m64p_core_param param_type, int new_value) noexcept
+        core_.set_state_callback([this, &notify](m64p_core_param param_type, int new_value) noexcept
         {
-            if(param_type != M64PTypes::M64CORE_EMU_STATE)
+            if(param_type != M64CORE_EMU_STATE)
                 return;
 
             switch(new_value)
             {
-            case M64PTypes::M64EMU_RUNNING:
+            case M64EMU_RUNNING:
                 if(state_ == MupenState::Starting)
                 {
                     // To guarantee that stop() cannot be entered while starting we kept mutex_
@@ -157,13 +1081,13 @@ void Mupen64Plus::start(const StateCallback& fn)
                 }
                 notify(Emulator::State::RUNNING);
                 break;
-            case M64PTypes::M64EMU_PAUSED:
+            case M64EMU_PAUSED:
                 mutex_.lock();
                 state_ = MupenState::Paused;
                 mutex_.unlock();
                 notify(Emulator::State::PAUSED);
                 break;
-            case M64PTypes::M64EMU_STOPPED:
+            case M64EMU_STOPPED:
                 // This is to guarantee we own mutex_ when do_cmd returns
                 mutex_.lock();
                 state_ = MupenState::Joinable;
@@ -175,7 +1099,7 @@ void Mupen64Plus::start(const StateCallback& fn)
         });
 
         // Blocking call to execute rom
-        auto ret{core_.do_cmd(M64PTypes::M64CMD_EXECUTE, 0, nullptr)};
+        auto ret{core_.do_cmd(M64CMD_EXECUTE, 0, nullptr)};
 
         detach_plugins();
 
@@ -222,7 +1146,7 @@ void Mupen64Plus::stop()
 
     // Emulator running, stop it
     log_noexcept(spdlog::level::info, "Stopping n64 emulation");
-    core_.do_cmd(M64PTypes::M64CMD_STOP, 0, nullptr);
+    core_.do_cmd(M64CMD_STOP, 0, nullptr);
     state_ = MupenState::Stopping;
     mutex_.unlock();
 
@@ -231,7 +1155,7 @@ void Mupen64Plus::stop()
     {
         std::this_thread::yield();
         // Workaround for: https://github.com/mupen64plus/mupen64plus-core/issues/681
-        core_.do_cmd(M64PTypes::M64CMD_STOP, 0, nullptr);
+        core_.do_cmd(M64CMD_STOP, 0, nullptr);
     }
 }
 
@@ -277,9 +1201,13 @@ State Mupen64Plus::state() const
         return Emulator::State::PAUSED;
     case MupenState::Stopped:
         return Emulator::State::STOPPED;
+    default:
+        assert(false);
+        break;
     }
 
-    assert(false);
+    // Silence warning
+    return Emulator::State::STOPPED;
 }
 
 bool Mupen64Plus::rom_loaded() const
@@ -290,8 +1218,6 @@ bool Mupen64Plus::rom_loaded() const
 void Mupen64Plus::attach_plugins() noexcept
 {
     // We already own mutex_
-    using namespace M64PTypes;
-
     core_.attach_plugin(*plugins_[M64PLUGIN_GFX]);
     core_.attach_plugin(*plugins_[M64PLUGIN_AUDIO]);
     core_.attach_plugin(*plugins_[M64PLUGIN_INPUT]);
@@ -301,8 +1227,6 @@ void Mupen64Plus::attach_plugins() noexcept
 void Mupen64Plus::detach_plugins() noexcept
 {
     // We already own mutex_
-    using namespace M64PTypes;
-
     core_.detach_plugin(plugins_[M64PLUGIN_GFX]->info().type);
     core_.detach_plugin(plugins_[M64PLUGIN_AUDIO]->info().type);
     core_.detach_plugin(plugins_[M64PLUGIN_INPUT]->info().type);
@@ -317,6 +1241,51 @@ void Mupen64Plus::logical2physical(addr_t& addr)
         throw std::system_error(Error::INVALID_ADDR);
     }
     addr -= LOGICAL_BASE;
+}
+
+void Mupen64Plus::prepare_config()
+{
+#define IGNR(x) try{x}catch(const std::system_error&){}
+
+    auto config{core_.config()};
+
+    try
+    {
+        config.list_sections([this, &config](const char* name)
+        {
+            // Disable certain hotkeys
+            if(std::strcmp(name, "CoreEvents") == 0)
+            {
+                auto section{config.open_section("CoreEvents")};
+
+                for(const auto hotkey : FORBIDDEN_HOTKEYS)
+                {
+                    IGNR(section.set(hotkey, "");)
+                }
+            }
+            else if(std::strcmp(name, "Core") == 0)
+            {
+                auto section{config.open_section("Core")};
+
+                // Enable 8MB
+                IGNR(section.set("DisableExtraMem", false);)
+                // Set screenshot path
+                IGNR(section.set("ScreenshotPath", (fs::path(emulator_root_) / "screenshot").string().c_str());)
+                // Set savestate path
+                IGNR(section.set("SaveStatePath", (fs::path(emulator_root_) / "save").string().c_str());)
+                // Set savegame path
+                IGNR(section.set("SaveSRAMPath", (fs::path(emulator_root_) / "save").string().c_str());)
+            }
+        });
+
+        config.save();
+    }
+    catch(const std::system_error& e)
+    {
+        logger()->error("Failed to prepare configuration: {}", e.what());
+    }
+
+#undef IGNR
 }
 
 void Mupen64Plus::check_bounds(addr_t addr, usize_t size)
@@ -341,7 +1310,7 @@ void Mupen64Plus::log_noexcept(spdlog::level::level_enum lvl, const char* msg) n
     }
 }
 
-bool Mupen64Plus::has_plugin(M64PTypes::m64p_plugin_type type) const
+bool Mupen64Plus::has_plugin(m64p_plugin_type type) const
 {
     std::lock_guard g(const_cast<Mupen64Plus*>(this)->mutex_);
 
@@ -561,72 +1530,3 @@ void Mupen64Plus::write(addr_t addr, f64 val)
 }
 
 } // Net64::Emulator
-
-
-namespace
-{
-
-const struct M64PlusErrorCategory : std::error_category
-{
-    const char* name() const noexcept override
-    {
-        return "mupen64plus";
-    }
-    std::string message(int ev) const override
-    {
-        using Net64::Emulator::M64PlusHelper::Error;
-        
-        switch(static_cast<Error>(ev))
-        {
-        case Error::NOT_INIT:
-            return "Function is disallowed before InitMupen64Plus() is called";
-        case Error::ALREADY_INIT:
-            return "InitMupen64Plus() was called twice";
-        case Error::INCOMPATIBLE:
-            return "API versions between components are incompatible";
-        case Error::INPUT_ASSERT:
-            return "Invalid parameters for function call";
-        case Error::INPUT_INVALID:
-            return "Invalid input data";
-        case Error::INPUT_NOT_FOUND:
-            return "The input parameter(s) specified a particular item which was not found";
-        case Error::NO_MEMORY:
-            return "Memory allocation failed";
-        case Error::FILES:
-            return "Error opening, creating, reading, or writing to a file";
-        case Error::INTERNAL:
-            return "Internal error (bug)";
-        case Error::INVALID_STATE:
-            return "Current program state does not allow operation";
-        case Error::PLUGIN_FAIL:
-            return "A plugin function returned a fatal error";
-        case Error::SYSTEM_FAIL:
-            return "A system function call, such as an SDL or file operation, failed";
-        case Error::UNSUPPORTED:
-            return "Function call is not supported";
-        case Error::WRONG_TYPE:
-            return "A given input type parameter cannot be used for desired operation";
-
-        case Error::LIB_LOAD_FAILED:
-            return "Failed to load library file";
-        case Error::INVALID_ADDR:
-            return "Tried to access out of bounds memory";
-        case Error::SYM_NOT_FOUND:
-            return "A symbol required by the API could not be located in the specified module";
-        default:
-            return "[Unknown Error]";
-        }
-    }
-}m64p_error_category_g;
-
-} // anonymous
-
-namespace Net64::Emulator::M64PlusHelper
-{
-
-std::error_code make_error_code(Error e) noexcept
-{
-    return {static_cast<int>(e), m64p_error_category_g};
-}
-
-} // Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus.cpp
+++ b/src/net64/emulator/m64plus.cpp
@@ -5,39 +5,37 @@
 // Refer to the LICENSE file included
 //
 
-#include "m64plus.hpp"
-
 #include <algorithm>
+
 #include <SDL_joystick.h>
 #include <net64/error_codes.hpp>
+
+#include "m64plus.hpp"
 #include "net64/memory/util.hpp"
 
 
 namespace Net64::Emulator
 {
-
 namespace
 {
-
 bool failed(Mupen64Plus::Error err)
 {
     return err != Mupen64Plus::Error::SUCCESS;
 }
 
-const std::array<const char*, 7> FORBIDDEN_HOTKEYS{
-    "Kbd Mapping Load State", "Kbd Mapping Speed Down",
-    "Kbd Mapping Speed Up", "Kbd Mapping Pause",
-    "Kbd Mapping Fast Forward", "Kbd Mapping Frame Advance",
-    "Kbd Mapping Gameshark"
-};
+const std::array<const char*, 7> FORBIDDEN_HOTKEYS{"Kbd Mapping Load State",
+                                                   "Kbd Mapping Speed Down",
+                                                   "Kbd Mapping Speed Up",
+                                                   "Kbd Mapping Pause",
+                                                   "Kbd Mapping Fast Forward",
+                                                   "Kbd Mapping Frame Advance",
+                                                   "Kbd Mapping Gameshark"};
 
-}
+} // namespace
 
 struct Mupen64PlusAudioSettings : IAudioSettings
 {
-    explicit Mupen64PlusAudioSettings(M64PlusHelper::Core& core):
-        core_(&core)
-    {}
+    explicit Mupen64PlusAudioSettings(M64PlusHelper::Core& core): core_(&core) {}
 
     bool get_volume(float& vol) override
     {
@@ -89,9 +87,7 @@ private:
 
 struct Mupen64PlusVideoSettings : IVideoSettings
 {
-    explicit Mupen64PlusVideoSettings(M64PlusHelper::Core& core):
-        core_(&core)
-    {}
+    explicit Mupen64PlusVideoSettings(M64PlusHelper::Core& core): core_(&core) {}
 
     bool get_fullscreen(bool& fullscreen) override
     {
@@ -217,7 +213,8 @@ struct Mupen64PlusControllerSettings : IControllerSettings
 {
     explicit Mupen64PlusControllerSettings(M64PlusHelper::Core& core, unsigned short joy_index):
         core_{&core}, joy_index_{joy_index}
-    {}
+    {
+    }
 
     bool get_device(std::string& device, int& device_index) override
     {
@@ -333,7 +330,7 @@ struct Mupen64PlusControllerSettings : IControllerSettings
         {
             auto section{open_section()};
 
-            auto[x, y]{parse_analog_xy(section.get_string("AnalogDeadzone"))};
+            auto [x, y]{parse_analog_xy(section.get_string("AnalogDeadzone"))};
 
             // Ignore the  y deadzone
             (void)y;
@@ -353,7 +350,7 @@ struct Mupen64PlusControllerSettings : IControllerSettings
         {
             auto section{open_section()};
 
-            auto[x, y]{parse_analog_xy(section.get_string("AnalogPeak"))};
+            auto [x, y]{parse_analog_xy(section.get_string("AnalogPeak"))};
 
             // Ignore the  y peak
             (void)y;
@@ -541,7 +538,8 @@ struct Mupen64PlusControllerSettings : IControllerSettings
         {
             auto section{open_section()};
 
-            auto absolute_deadzone{std::to_string(static_cast<unsigned>(deadzone * std::numeric_limits<std::int16_t>::max()))};
+            auto absolute_deadzone{
+                std::to_string(static_cast<unsigned>(deadzone * std::numeric_limits<std::int16_t>::max()))};
 
             section.set("AnalogDeadzone", std::string(absolute_deadzone + ',' + absolute_deadzone).c_str());
 
@@ -565,7 +563,8 @@ struct Mupen64PlusControllerSettings : IControllerSettings
         {
             auto section{open_section()};
 
-            auto absolute_peak{std::to_string(static_cast<unsigned>(peak * (std::numeric_limits<std::uint16_t>::max() / 2)))};
+            auto absolute_peak{
+                std::to_string(static_cast<unsigned>(peak * (std::numeric_limits<std::uint16_t>::max() / 2)))};
 
             section.set("AnalogPeak", std::string(absolute_peak + ',' + absolute_peak).c_str());
 
@@ -605,15 +604,10 @@ struct Mupen64PlusControllerSettings : IControllerSettings
 private:
     M64PlusHelper::ConfigSection open_section()
     {
-        return core_->config().open_section(
-            std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str()
-        );
+        return core_->config().open_section(std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str());
     }
 
-    void save()
-    {
-        core_->config().save(std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str());
-    }
+    void save() { core_->config().save(std::string("Input-SDL-Control" + std::to_string(joy_index_ + 1)).c_str()); }
 
     static std::string format_analog_xy(std::int16_t x, std::int16_t y)
     {
@@ -629,11 +623,10 @@ private:
 
         try
         {
-            auto xy{std::make_pair<unsigned long , unsigned long>(std::stoul(str), std::stoul(str.c_str() + c + 1))};
+            auto xy{std::make_pair<unsigned long, unsigned long>(std::stoul(str), std::stoul(str.c_str() + c + 1))};
             std::pair<std::int16_t, std::int16_t> ret(
                 std::clamp(xy.first, 0ul, (unsigned long)std::numeric_limits<std::int16_t>::max()),
-                std::clamp(xy.second, 0ul, (unsigned long)std::numeric_limits<std::int16_t>::max())
-            );
+                std::clamp(xy.second, 0ul, (unsigned long)std::numeric_limits<std::int16_t>::max()));
 
             return ret;
         }
@@ -643,10 +636,7 @@ private:
         }
     }
 
-    static const char* n64_button_str(N64Button btn)
-    {
-        return btn_enum2str_s[static_cast<unsigned>(btn)];
-    }
+    static const char* n64_button_str(N64Button btn) { return btn_enum2str_s[static_cast<unsigned>(btn)]; }
 
     static std::pair<sdl_input_t, sdl_input_t> parse_sdl_input(const std::string& str)
     {
@@ -658,8 +648,7 @@ private:
             return input;
 
         /// Splits string at ',' & ' '
-        auto get_args{[](std::string_view str) -> std::vector<std::string>
-        {
+        auto get_args{[](std::string_view str) -> std::vector<std::string> {
             std::vector<std::string> args;
 
             auto begin{str.find_first_of('(') + 1};
@@ -718,7 +707,7 @@ private:
             input.first.type = sdl_input_t::Type::JOY_AXIS;
             input.first.joy.index = std::stoi(args[0]);
             input.first.joy.value = (args[0].back() == '+' ? 1 : -1);
-            
+
             if(args.size() > 1)
             {
                 input.second.type = input.first.type;
@@ -728,8 +717,7 @@ private:
         }
         else if((begin = str.find("hat(")) != std::string::npos)
         {
-            auto parse_dir = [](std::string_view str, int& c)
-            {
+            auto parse_dir = [](std::string_view str, int& c) {
                 if(str == "Up")
                     c = SDL_HAT_UP;
                 else if(str == "Down")
@@ -782,18 +770,14 @@ private:
     static void set_button(M64PlusHelper::ConfigSection section, N64Button n64_button, sdl_input_t input)
     {
         // Special treatment for analog stick
-        if(n64_button == N64Button::ANALOG_DOWN  ||
-           n64_button == N64Button::ANALOG_UP ||
-           n64_button == N64Button::ANALOG_LEFT ||
-           n64_button == N64Button::ANALOG_RIGHT)
+        if(n64_button == N64Button::ANALOG_DOWN || n64_button == N64Button::ANALOG_UP ||
+           n64_button == N64Button::ANALOG_LEFT || n64_button == N64Button::ANALOG_RIGHT)
         {
-            auto set{[&section](N64Button n64_button, const std::string& str)
-            {
+            auto set{[&section](N64Button n64_button, const std::string& str) {
                 section.set(n64_button_str(n64_button), str.c_str());
             }};
 
-            auto get_pair{[&section, input, n64_button]() -> std::pair<sdl_input_t, sdl_input_t>
-            {
+            auto get_pair{[&section, input, n64_button]() -> std::pair<sdl_input_t, sdl_input_t> {
                 N64Button first{n64_button}, second{};
 
                 switch(n64_button)
@@ -818,7 +802,8 @@ private:
                 if(first == N64Button::ANALOG_RIGHT || first == N64Button::ANALOG_DOWN)
                     swap = true;
 
-                // Mupen64Plus doesn't support binding two different input types to the same axis (or two different hats)
+                // Mupen64Plus doesn't support binding two different input types to the same axis (or two different
+                // hats)
                 if(opposite_bind.type != input.type ||
                    (input.type == sdl_input_t::Type::JOY_HAT && input.joy.index != opposite_bind.joy.index))
                 {
@@ -832,38 +817,45 @@ private:
             }};
 
 
-            auto[first, second]{get_pair()};
+            auto [first, second]{get_pair()};
 
             switch(input.type != sdl_input_t::Type::NONE ? input.type : second.type)
             {
             case sdl_input_t::Type::KEY:
-                set(n64_button, "key(" +
-                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.key_code)) + ',' +
-                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.key_code)) + ")");
+                set(n64_button,
+                    "key(" + (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.key_code)) + ',' +
+                        (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.key_code)) + ")");
                 break;
             case sdl_input_t::Type::JOY_AXIS:
-                set(n64_button, "axis(" +
-                    (first.type == sdl_input_t::Type::NONE ? "" :
-                        std::to_string(first.joy.index) + (first.joy.value < 0 ? "-" : "+")) + std::string(",") +
-                    (second.type == sdl_input_t::Type::NONE ? "" :
-                        std::to_string(second.joy.index) + (second.joy.value < 0 ? "-" : "+")) + std::string(")"));
+                set(n64_button,
+                    "axis(" +
+                        (first.type == sdl_input_t::Type::NONE ?
+                             "" :
+                             std::to_string(first.joy.index) + (first.joy.value < 0 ? "-" : "+")) +
+                        std::string(",") +
+                        (second.type == sdl_input_t::Type::NONE ?
+                             "" :
+                             std::to_string(second.joy.index) + (second.joy.value < 0 ? "-" : "+")) +
+                        std::string(")"));
                 break;
             case sdl_input_t::Type::JOY_BUTTON:
-                set(n64_button, "button(" +
-                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.joy.index)) + ',' +
-                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.joy.index)) + ")");
+                set(n64_button,
+                    "button(" + (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.joy.index)) + ',' +
+                        (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.joy.index)) + ")");
                 break;
             case sdl_input_t::Type::JOY_HAT:
-                set(n64_button, "hat(" +
-                    (first.type == sdl_input_t::Type::NONE ? std::to_string(second.joy.index) + " " + sdl_hat_direction(second.joy.value) :
-                        std::to_string(first.joy.index) + " " + sdl_hat_direction(first.joy.value)) +
-                    (second.type == sdl_input_t::Type::NONE ? "" :
-                        " " + sdl_hat_direction(second.joy.value)) + ")");
+                set(n64_button,
+                    "hat(" +
+                        (first.type == sdl_input_t::Type::NONE ?
+                             std::to_string(second.joy.index) + " " + sdl_hat_direction(second.joy.value) :
+                             std::to_string(first.joy.index) + " " + sdl_hat_direction(first.joy.value)) +
+                        (second.type == sdl_input_t::Type::NONE ? "" : " " + sdl_hat_direction(second.joy.value)) +
+                        ")");
                 break;
             case sdl_input_t::Type::MOUSE_BUTTON:
-                set(n64_button, "mouse(" +
-                    (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.mouse_button)) + ',' +
-                    (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.mouse_button)) + ")");
+                set(n64_button,
+                    "mouse(" + (first.type == sdl_input_t::Type::NONE ? "" : std::to_string(first.mouse_button)) + ',' +
+                        (second.type == sdl_input_t::Type::NONE ? "" : std::to_string(second.mouse_button)) + ")");
                 break;
             case sdl_input_t::Type::NONE:
                 set(n64_button, "");
@@ -878,8 +870,7 @@ private:
                 return;
             }
 
-            auto set{[&section](N64Button n64_button, const std::string& str)
-            {
+            auto set{[&section](N64Button n64_button, const std::string& str) {
                 section.set(n64_button_str(n64_button), str.c_str());
             }};
 
@@ -889,15 +880,16 @@ private:
                 set(n64_button, "key(" + std::to_string(input.key_code) + ")");
                 break;
             case sdl_input_t::Type::JOY_AXIS:
-                set(n64_button, "axis(" + std::to_string(input.joy.index) +
-                    (input.joy.value < 0 ? "-" : "+") +
-                    std::string(",9830)")); // We'll use a default analog to digital trigger of 30%
+                set(n64_button,
+                    "axis(" + std::to_string(input.joy.index) + (input.joy.value < 0 ? "-" : "+") +
+                        std::string(",9830)")); // We'll use a default analog to digital trigger of 30%
                 break;
             case sdl_input_t::Type::JOY_BUTTON:
                 set(n64_button, "button(" + std::to_string(input.joy.index) + ")");
                 break;
             case sdl_input_t::Type::JOY_HAT:
-                set(n64_button, "hat(" + std::to_string(input.joy.index) + ' ' + sdl_hat_direction(input.joy.value) + ")");
+                set(n64_button,
+                    "hat(" + std::to_string(input.joy.index) + ' ' + sdl_hat_direction(input.joy.value) + ")");
                 break;
             case sdl_input_t::Type::MOUSE_BUTTON:
                 set(n64_button, "mouse(" + std::to_string(input.mouse_button) + ")");
@@ -920,18 +912,29 @@ private:
     unsigned short joy_index_;
 
     inline static const std::array<const char*, static_cast<unsigned>(N64Button::NUM_BUTTONS)> btn_enum2str_s{
-            "A Button", "B Button", "Z Trig", "L Trig", "R Trig",
-            "Start", "DPad U", "DPad D", "DPad L", "DPad R",
-            "C Button U", "C Button D", "C Button L", "C Button R",
-            "Y Axis", "Y Axis",
-            "X Axis", "X Axis"
-    };
+        "A Button",
+        "B Button",
+        "Z Trig",
+        "L Trig",
+        "R Trig",
+        "Start",
+        "DPad U",
+        "DPad D",
+        "DPad L",
+        "DPad R",
+        "C Button U",
+        "C Button D",
+        "C Button L",
+        "C Button R",
+        "Y Axis",
+        "Y Axis",
+        "X Axis",
+        "X Axis"};
 };
 
 
 Mupen64Plus::Mupen64Plus(const std::string& lib_path, std::string root_path, std::string data_path):
-    core_{lib_path, root_path, std::move(data_path)},
-    emulator_root_{std::move(root_path)}
+    core_{lib_path, root_path, std::move(data_path)}, emulator_root_{std::move(root_path)}
 {
     assert(!has_instance_s);
     has_instance_s = true;
@@ -993,7 +996,7 @@ void Mupen64Plus::load_rom(void* rom_data, std::size_t n)
 
     prepare_config();
 
-    auto ret {core_.do_cmd(M64CMD_ROM_OPEN, static_cast<int>(n), rom_data)};
+    auto ret{core_.do_cmd(M64CMD_ROM_OPEN, static_cast<int>(n), rom_data)};
     if(failed(ret))
     {
         std::system_error err(make_error_code(ret), "Failed to load ROM image");
@@ -1027,9 +1030,12 @@ void Mupen64Plus::start(const StateCallback& fn)
     assert(rom_loaded_);
 
     // Safely call callback
-    auto notify{[fn](Emulator::State state) noexcept
-    {
-        try{if(fn) fn(state);}
+    auto notify{[fn](Emulator::State state) noexcept {
+        try
+        {
+            if(fn)
+                fn(state);
+        }
         catch(...)
         {
             log_noexcept(spdlog::level::warn, "Exception in user state callback");
@@ -1050,8 +1056,7 @@ void Mupen64Plus::start(const StateCallback& fn)
     log_noexcept(spdlog::level::info, "Starting n64 emulation");
     state_ = MupenState::Starting;
 
-    emulation_thread_ = std::async([this, notify]()
-    {
+    emulation_thread_ = std::async([this, notify]() {
         try
         {
             attach_plugins();
@@ -1063,8 +1068,7 @@ void Mupen64Plus::start(const StateCallback& fn)
             throw;
         }
 
-        core_.set_state_callback([this, &notify](m64p_core_param param_type, int new_value) noexcept
-        {
+        core_.set_state_callback([this, &notify](m64p_core_param param_type, int new_value) noexcept {
             if(param_type != M64CORE_EMU_STATE)
                 return;
 
@@ -1168,7 +1172,10 @@ void Mupen64Plus::join(std::error_code& exit_code)
 
     // Emulator is stopped, join the emulation thread
     mutex_.lock();
-    try{emulation_thread_.get();}
+    try
+    {
+        emulation_thread_.get();
+    }
     catch(const std::system_error& e)
     {
         exit_code = e.code();
@@ -1245,14 +1252,20 @@ void Mupen64Plus::logical2physical(addr_t& addr)
 
 void Mupen64Plus::prepare_config()
 {
-#define IGNR(x) try{x}catch(const std::system_error&){}
+#define IGNR(x)                     \
+    try                             \
+    {                               \
+        x                           \
+    }                               \
+    catch(const std::system_error&) \
+    {                               \
+    }
 
     auto config{core_.config()};
 
     try
     {
-        config.list_sections([this, &config](const char* name)
-        {
+        config.list_sections([this, &config](const char* name) {
             // Disable certain hotkeys
             if(std::strcmp(name, "CoreEvents") == 0)
             {
@@ -1305,7 +1318,7 @@ void Mupen64Plus::log_noexcept(spdlog::level::level_enum lvl, const char* msg) n
     {
         logger()->log(lvl, msg);
     }
-    catch (...)
+    catch(...)
     {
     }
 }
@@ -1314,7 +1327,7 @@ bool Mupen64Plus::has_plugin(m64p_plugin_type type) const
 {
     std::lock_guard g(const_cast<Mupen64Plus*>(this)->mutex_);
 
-    if (plugins_[type])
+    if(plugins_[type])
         return true;
     return false;
 }
@@ -1329,12 +1342,10 @@ void Mupen64Plus::read_memory(addr_t addr, void* data, usize_t n)
     // First copy the aligned chunk
 
     // Calc unaligned leftovers
-    usize_t begin_left{BSWAP_SIZE - (addr % BSWAP_SIZE)},
-            end_left{(addr + n) % BSWAP_SIZE};
+    usize_t begin_left{BSWAP_SIZE - (addr % BSWAP_SIZE)}, end_left{(addr + n) % BSWAP_SIZE};
 
     // Address and length of aligned part
-    addr_t aligned_addr{addr + begin_left},
-           aligned_len{n - end_left - (aligned_addr - addr)};
+    addr_t aligned_addr{addr + begin_left}, aligned_len{n - end_left - (aligned_addr - addr)};
 
 
     // Copy & bswap the aligned chunk
@@ -1347,8 +1358,8 @@ void Mupen64Plus::read_memory(addr_t addr, void* data, usize_t n)
     u32 begin_word{};
     read(begin_addr, begin_word);
     Memory::bswap32(&begin_word, sizeof(begin_word));
-    std::copy_n(reinterpret_cast<u8*>(&begin_word) + (BSWAP_SIZE - begin_left),
-                begin_left, reinterpret_cast<u8*>(data));
+    std::copy_n(
+        reinterpret_cast<u8*>(&begin_word) + (BSWAP_SIZE - begin_left), begin_left, reinterpret_cast<u8*>(data));
 
     // Unaligned ending
     auto end_addr{aligned_addr + aligned_len};
@@ -1363,12 +1374,10 @@ void Mupen64Plus::write_memory(addr_t addr, const void* data, usize_t n)
     auto ptr{get_mem_ptr<u8>()};
 
     // Calc unaligned padding
-    usize_t begin_padding{addr % BSWAP_SIZE},
-            end_padding{BSWAP_SIZE - ((addr + n) % BSWAP_SIZE)};
+    usize_t begin_padding{addr % BSWAP_SIZE}, end_padding{BSWAP_SIZE - ((addr + n) % BSWAP_SIZE)};
 
     // Aligned chunk
-    addr_t aligned_addr{addr - begin_padding},
-           aligned_len{n + begin_padding + end_padding};
+    addr_t aligned_addr{addr - begin_padding}, aligned_len{n + begin_padding + end_padding};
 
 
     logical2physical(addr);
@@ -1529,4 +1538,4 @@ void Mupen64Plus::write(addr_t addr, f64 val)
     std::copy_n(reinterpret_cast<u8*>(&val), sizeof(val), ptr + addr);
 }
 
-} // Net64::Emulator
+} // namespace Net64::Emulator

--- a/src/net64/emulator/m64plus.hpp
+++ b/src/net64/emulator/m64plus.hpp
@@ -16,262 +16,20 @@
 #include <optional>
 #include <mutex>
 #include "net64/emulator/emulator.hpp"
+#include "net64/emulator/m64plus_error.hpp"
+#include "net64/emulator/m64plus_plugin.hpp"
 #include "net64/emulator/shared_library.hpp"
 #include "net64/logging.hpp"
 
 
 namespace Net64::Emulator
 {
-class Mupen64Plus;
-
-// Don't pollute global namespace
-namespace M64PTypes
-{
-#include <mupen64plus/m64p_types.h>
-} // M64PTypes
-
-namespace M64PlusHelper
-{
-
-class Plugin;
-
-/// Mupen64Plus error codes
-enum struct Error
-{
-    // Mupen64Plus internal errors
-    SUCCESS = 0,
-    NOT_INIT,        ///< Function is disallowed before InitMupen64Plus() is called
-    ALREADY_INIT,    ///< InitMupen64Plus() was called twice
-    INCOMPATIBLE,    ///< API versions between components are incompatible
-    INPUT_ASSERT,    ///< Invalid parameters for function call, such as ParamValue=NULL for GetCoreParameter()
-    INPUT_INVALID,   ///< Invalid input data, such as ParamValue="maybe" for SetCoreParameter() to set a BOOL-type value
-    INPUT_NOT_FOUND, ///< The input parameter(s) specified a particular item which was not found
-    NO_MEMORY,       ///< Memory allocation failed
-    FILES,           ///< Error opening, creating, reading, or writing to a file
-    INTERNAL,        ///< Internal error (bug)
-    INVALID_STATE,   ///< Current program state does not allow operation
-    PLUGIN_FAIL,     ///< A plugin function returned a fatal error
-    SYSTEM_FAIL,     ///< A system function call, such as an SDL or file operation, failed
-    UNSUPPORTED,     ///< Function call is not supported (ie, core not built with debugger)
-    WRONG_TYPE,      ///< A given input type parameter cannot be used for desired operation
-    // Interface errors
-    LIB_LOAD_FAILED, ///< Failed to load library file
-    INVALID_ADDR,    ///< Tried to access out of bounds memory
-    SYM_NOT_FOUND    ///< A symbol required by the API could not be located in the specified module
-};
-
-/// Overload for Mupen64Plus error codes
-std::error_code make_error_code(Error e) noexcept;
-
-
-/// Contains information retrieved via PluginGetVersion
-struct PluginInfo
-{
-    M64PTypes::m64p_plugin_type type{M64PTypes::M64PLUGIN_NULL};
-    int plugin_version{},
-        api_version{},
-        capabilities{};
-    std::string name;
-};
-
-/**
- * Dynamically loaded Mupen64Plus core
- */
-class Core final
-{
-    friend class ::Net64::Emulator::Mupen64Plus;
-    friend class ::Net64::Emulator::M64PlusHelper::Plugin;
-
-    // Function pointer types
-    using plugin_get_version_t = Error(CALL*)(M64PTypes::m64p_plugin_type*, int*, int*, const char**, int*);
-    using debug_context_t = void*;
-    using debug_callback_t = void(*)(void*, int, const char*);
-    using state_context_t = void*;
-    using state_callback_t = void(*)(void*, M64PTypes::m64p_core_param, int);
-    using core_startup_t = Error(CALL*)(int, const char*, const char*,
-                                    debug_context_t, debug_callback_t,
-                                    state_context_t, state_callback_t);
-    using core_shutdown_t = Error(CALL*)();
-    using core_attach_plugin_t = Error(CALL*)(M64PTypes::m64p_plugin_type, M64PTypes::m64p_dynlib_handle);
-    using core_detach_plugin_t = Error(CALL*)(M64PTypes::m64p_plugin_type);
-    using core_do_cmd_t = Error(CALL*)(M64PTypes::m64p_command, int, void*);
-    using debug_get_mem_ptr_t = volatile void* (CALL*)(M64PTypes::m64p_dbg_memptr_type);
-
-    using list_config_sections_t = Error(CALL*)(void*, void(*)(void*, const char*));
-    using open_config_section_t = Error(CALL*)(const char*, M64PTypes::m64p_handle*);
-    using save_config_file_t = void(CALL*)();
-    using set_config_parameter_t = Error(CALL*)(M64PTypes::m64p_handle, const char*, M64PTypes::m64p_type, const void*);
-
-    using state_callback_f = std::function<void(M64PTypes::m64p_core_param, int)>;
-    using debug_callback_f = std::function<void(int, const char*)>;
-
-    /// Mupen64Plus API this frontend is compatible with
-    static constexpr int API_VERSION{0x020001};
-
-    /// Create core from current process
-    Core(std::string root_path, std::string data_path);
-
-    /// Create core from dynamic library handle
-    Core(dynlib_t lib, std::string root_path, std::string data_path);
-
-    /// Create core from library file
-    Core(const std::string& lib_path, std::string root_path, std::string data_path);
-
-    /// Non copyable
-    Core(const Core&) = delete;
-
-    /// Non movable
-    Core(Core&& other) = delete;
-
-    ~Core();
-
-    void prepare_config_file();
-
-    void attach_plugin(Plugin& plugin);
-
-    void detach_plugin(M64PTypes::m64p_plugin_type type);
-
-    /// Return pointer to n64 DRAM
-    volatile void* get_mem_ptr();
-
-    Error do_cmd(M64PTypes::m64p_command cmd, int p1, void* p2);
-
-    void list_config_sections(void* context, void(*callback)(void* context, const char* name));
-
-    M64PTypes::m64p_handle open_config_section(const char* name);
-
-    void save_config_file();
-
-    void set_config_parameter(M64PTypes::m64p_handle handle, const char* param_name,
-                              M64PTypes::m64p_type type, const void* data);
-
-    void set_state_callback(state_callback_f cb) noexcept;
-    void set_debug_callback(debug_callback_f cb) noexcept;
-
-    /// Return native library handle
-    dynlib_t handle();
-
-    /// Return general information about the core
-    const PluginInfo& info() const;
-
-    void init_symbols();
-    void init_core();
-    void create_folder_structure();
-    void destroy_core();
-
-    static void state_callback_c(void* context, M64PTypes::m64p_core_param param_type, int new_value);
-    static void debug_callback_c(void* context, int level, const char* message);
-
-    template<typename T>
-    void resolve_symbol(T& fn_ptr, const char* name)
-    {
-        fn_ptr = reinterpret_cast<T>(get_symbol(handle_.lib, name));
-    }
-
-    UniqueLib handle_{};
-    struct CoreFunctions
-    {
-        plugin_get_version_t plugin_get_version;
-        core_startup_t core_startup;
-        core_shutdown_t core_shutdown;
-        core_attach_plugin_t core_attach_plugin;
-        core_detach_plugin_t core_detach_plugin;
-        core_do_cmd_t core_do_cmd;
-        debug_get_mem_ptr_t debug_get_mem_ptr;
-        list_config_sections_t list_config_sections;
-        open_config_section_t open_config_section;
-        save_config_file_t save_config_file;
-        set_config_parameter_t set_config_parameter;
-    }fn_{};
-    PluginInfo info_;
-    std::unique_ptr<state_callback_f> state_callback_ = std::make_unique<state_callback_f>();
-    std::unique_ptr<debug_callback_f> debug_callback_ = std::make_unique<debug_callback_f>();
-
-    std::string root_path_,
-                data_path_;
-
-    static const std::vector<std::string> FORBIDDEN_HOTKEYS;
-
-    CLASS_LOGGER_("mupen64plus");
-};
-
-/**
- * Dynamically loaded Mupen64Plus plugin
- */
-class Plugin final
-{
-    friend class ::Net64::Emulator::Mupen64Plus;
-    friend class ::Net64::Emulator::M64PlusHelper::Core;
-
-public:
-    /// Non copyable
-    Plugin(const Plugin&) = delete;
-
-    /// Non movable
-    Plugin(Plugin&& other) = delete;
-
-    ~Plugin();
-
-    /**
-     * Load file as plugin and return information about it.
-     * Returns type = M64PLUGIN_NULL if not a plugin
-     */
-    static PluginInfo get_plugin_info(const std::string& file);
-    static PluginInfo get_plugin_info(dynlib_t lib);
-
-    /// Get string representation of plugin type id
-    static const char* type_str(M64PTypes::m64p_plugin_type type_id);
-
-private:
-    // Function pointer types
-    using plugin_startup_t = Error(CALL*)(M64PTypes::m64p_dynlib_handle, void*, void* (*)(void*, int, const char*));
-    using plugin_shutdown_t = Error(CALL*)();
-    using plugin_get_version_t = Error(CALL*)(M64PTypes::m64p_plugin_type*, int*, int*, const char**, int*);
-
-    /// Create plugin from dynamic library handle
-    Plugin(Core& core, dynlib_t lib);
-
-    /// Create plugin from library path
-    Plugin(Core& core, const std::string& lib_path);
-
-    /// Return general information about the plugin
-    const PluginInfo& info() const;
-
-    /// Return native library handle
-    dynlib_t handle();
-
-    void init_symbols();
-    void init_plugin(dynlib_t core_lib);
-    void destroy_plugin();
-
-    template<typename T>
-    void resolve_symbol(T& fn_ptr, const char* name)
-    {
-        fn_ptr = reinterpret_cast<T>(get_symbol(handle_.lib, name));
-    }
-
-    UniqueLib handle_{};
-    struct
-    {
-        plugin_startup_t startup;
-        plugin_shutdown_t shutdown;
-        plugin_get_version_t get_version;
-    }fn_{};
-    PluginInfo info_;
-
-    CLASS_LOGGER_("mupen64plus");
-};
-
-#undef CALL
-
-} // M64PlusHelper
 
 /**
  * Mupen64Plus instance. Only one instance of this class can be alive at a time.
  */
-class Mupen64Plus final : public IEmulator
+struct Mupen64Plus final : IEmulator
 {
-public:
     using Core = M64PlusHelper::Core;
     using Plugin = M64PlusHelper::Plugin;
     using PluginInfo = M64PlusHelper::PluginInfo;
@@ -290,11 +48,17 @@ public:
 
     ~Mupen64Plus() override;
 
+    std::unique_ptr<IAudioSettings> audio_settings() override;
+
+    std::unique_ptr<IVideoSettings> video_settings() override;
+
+    std::unique_ptr<IControllerSettings> controller_settings(unsigned short controller) override;
+
     /// Register a plugin
     void add_plugin(const std::string& lib_path);
 
     /// Remove a plugin
-    void remove_plugin(M64PTypes::m64p_plugin_type type);
+    void remove_plugin(m64p_plugin_type type);
 
     /// Load ROM image
     void load_rom(void* rom_data, std::size_t n) override;
@@ -336,11 +100,15 @@ public:
     bool rom_loaded() const;
 
     /// Check if plugin of a type is already registered
-    bool has_plugin(M64PTypes::m64p_plugin_type type) const;
+    bool has_plugin(m64p_plugin_type type) const;
 
 private:
     void attach_plugins() noexcept;
+
     void detach_plugins() noexcept;
+
+    void prepare_config();
+
     inline static void logical2physical(addr_t& addr);
     inline static void check_bounds(addr_t addr, usize_t size);
     static void log_noexcept(spdlog::level::level_enum lvl, const char* msg) noexcept;
@@ -362,8 +130,8 @@ private:
     }
 
     Core core_;
-    std::array<std::unique_ptr<Plugin>, M64PTypes::M64PLUGIN_MAX> plugins_{};
-
+    std::array<std::unique_ptr<Plugin>, M64PLUGIN_MAX> plugins_{};
+    std::string emulator_root_;
     bool rom_loaded_{};
 
     enum class MupenState
@@ -379,7 +147,7 @@ private:
     mutable std::mutex mutex_;
     std::future<void> emulation_thread_;
 
-    inline static bool has_instance = false;
+    inline static bool has_instance_s{false};
 
     CLASS_LOGGER_("mupen64plus")
 };

--- a/src/net64/emulator/m64plus.hpp
+++ b/src/net64/emulator/m64plus.hpp
@@ -10,11 +10,12 @@
 #include <array>
 #include <atomic>
 #include <future>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <optional>
-#include <mutex>
+
 #include "net64/emulator/emulator.hpp"
 #include "net64/emulator/m64plus_error.hpp"
 #include "net64/emulator/m64plus_plugin.hpp"
@@ -24,7 +25,6 @@
 
 namespace Net64::Emulator
 {
-
 /**
  * Mupen64Plus instance. Only one instance of this class can be alive at a time.
  */
@@ -65,7 +65,7 @@ struct Mupen64Plus final : IEmulator
 
     void unload_rom() override;
 
-    //void execute(const StateCallback& fn = {}) override;
+    // void execute(const StateCallback& fn = {}) override;
     void start(const StateCallback& fn) override;
 
     void stop() override;
@@ -92,10 +92,7 @@ struct Mupen64Plus final : IEmulator
 
     State state() const override;
 
-    const char* name() const override
-    {
-        return "mupen64plus";
-    }
+    const char* name() const override { return "mupen64plus"; }
 
     bool rom_loaded() const;
 
@@ -152,9 +149,11 @@ private:
     CLASS_LOGGER_("mupen64plus")
 };
 
-} // Net64::Emulator
+} // namespace Net64::Emulator
 
 
 /// Specialization for Mupen64Plus error codes
 template<>
-struct std::is_error_code_enum<::Net64::Emulator::Mupen64Plus::Error> : std::true_type{};
+struct std::is_error_code_enum<::Net64::Emulator::Mupen64Plus::Error> : std::true_type
+{
+};

--- a/src/net64/emulator/m64plus_config.cpp
+++ b/src/net64/emulator/m64plus_config.cpp
@@ -1,0 +1,240 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#include "net64/emulator/m64plus_config.hpp"
+
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+Config::Config(dynlib_t core_lib):
+    core_(core_lib)
+{
+    load_symbols();
+}
+
+ConfigSection Config::open_section(const char* name)
+{
+    ConfigSection::cfg_section_hdl_t hdl{};
+
+    auto ret = fn_.config_open_section(name, &hdl);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return ConfigSection(core_, hdl);
+}
+
+void Config::save()
+{
+    auto ret = fn_.config_save_file();
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void Config::save(const char* section)
+{
+    auto ret = fn_.config_save_section(section);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void Config::delete_section(const char* section)
+{
+    auto ret = fn_.config_delete_section(section);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+bool Config::has_unsaved_changes(const char* section) const
+{
+    return static_cast<bool>(fn_.config_has_unsaved_changes(section));
+}
+
+void Config::revert_changes(const char* section)
+{
+    auto ret = fn_.config_revert_changes(section);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void Config::load_symbols()
+{
+    auto resolve{[this](auto& ptr, const char* name)
+    {
+        ptr = reinterpret_cast<std::remove_reference_t<decltype(ptr)>>(get_symbol(core_, name));
+        if(!ptr)
+            throw std::system_error(make_error_code(Error::SYM_NOT_FOUND));
+    }};
+
+    resolve(fn_.config_delete_section, "ConfigDeleteSection");
+    resolve(fn_.config_save_file, "ConfigSaveFile");
+    resolve(fn_.config_has_unsaved_changes, "ConfigHasUnsavedChanges");
+    resolve(fn_.config_open_section, "ConfigOpenSection");
+    resolve(fn_.config_list_sections, "ConfigListSections");
+    resolve(fn_.config_revert_changes, "ConfigRevertChanges");
+    resolve(fn_.config_save_section, "ConfigSaveSection");
+}
+
+
+ConfigSection::ConfigSection(dynlib_t core_lib, cfg_section_hdl_t section_hdl):
+    core_(core_lib), section_hdl_(section_hdl)
+{
+    load_symbols();
+}
+
+void ConfigSection::set_default(const char* param, int value, const char* help_str)
+{
+    auto ret = fn_.config_set_default_int(section_hdl_, param, value, help_str);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set_default(const char* param, float value, const char* help_str)
+{
+    auto ret = fn_.config_set_default_float(section_hdl_, param, value, help_str);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set_default(const char* param, bool value, const char* help_str)
+{
+    auto ret = fn_.config_set_default_bool(section_hdl_, param, value, help_str);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set_default(const char* param, const char* value, const char* help_str)
+{
+    auto ret = fn_.config_set_default_string(section_hdl_, param, value, help_str);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set(const char* param, int value)
+{
+    auto ret = fn_.config_set_parameter(section_hdl_, param, param_type_t::M64TYPE_INT, &value);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set(const char* param, float value)
+{
+    auto ret = fn_.config_set_parameter(section_hdl_, param, param_type_t::M64TYPE_FLOAT, &value);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set(const char* param, bool value)
+{
+    auto int_val{static_cast<int>(value)};
+    auto ret = fn_.config_set_parameter(section_hdl_, param, param_type_t::M64TYPE_BOOL, &int_val);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+void ConfigSection::set(const char* param, const char* value)
+{
+    auto ret = fn_.config_set_parameter(section_hdl_, param, param_type_t::M64TYPE_STRING, value);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+}
+
+const char* ConfigSection::help(const char* param)
+{
+    return fn_.config_get_parameter_help(section_hdl_, param);
+}
+
+ConfigSection::param_type_t ConfigSection::type(const char* param)
+{
+    param_type_t type;
+
+    auto ret = fn_.config_get_parameter_type(section_hdl_, param, &type);
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return type;
+}
+
+int ConfigSection::get_int(const char* param)
+{
+    int value;
+    auto ret = fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_INT, &value, sizeof(value));
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return value;
+}
+
+float ConfigSection::get_float(const char* param)
+{
+    float value;
+    auto ret = fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_FLOAT, &value, sizeof(value));
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return value;
+}
+
+bool ConfigSection::get_bool(const char* param)
+{
+    int value;
+    auto ret = fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_BOOL, &value, sizeof(value));
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return static_cast<bool>(value);
+}
+
+std::string ConfigSection::get_string(const char* param)
+{
+    std::string value(STRING_BUF_LEN, '\0');
+    auto ret = fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_STRING, value.data(), (int)value.size());
+
+    if(ret != Error::SUCCESS)
+        throw std::system_error(make_error_code(ret));
+
+    return value;
+}
+
+void ConfigSection::load_symbols()
+{
+    auto resolve{[this](auto& ptr, const char* name)
+    {
+        ptr = reinterpret_cast<std::remove_reference_t<decltype(ptr)>>(get_symbol(core_, name));
+        if(!ptr)
+            throw std::system_error(make_error_code(Error::SYM_NOT_FOUND));
+    }};
+
+    resolve(fn_.config_list_parameters, "ConfigListParameters");
+    resolve(fn_.config_get_parameter, "ConfigGetParameter");
+    resolve(fn_.config_get_parameter_help, "ConfigGetParameterHelp");
+    resolve(fn_.config_get_parameter_type, "ConfigGetParameterType");
+    resolve(fn_.config_set_default_bool, "ConfigSetDefaultBool");
+    resolve(fn_.config_set_default_float, "ConfigSetDefaultFloat");
+    resolve(fn_.config_set_default_int, "ConfigSetDefaultInt");
+    resolve(fn_.config_set_default_string, "ConfigSetDefaultString");
+    resolve(fn_.config_set_parameter, "ConfigSetParameter");
+}
+
+}

--- a/src/net64/emulator/m64plus_config.cpp
+++ b/src/net64/emulator/m64plus_config.cpp
@@ -10,9 +10,7 @@
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
-Config::Config(dynlib_t core_lib):
-    core_(core_lib)
+Config::Config(dynlib_t core_lib): core_(core_lib)
 {
     load_symbols();
 }
@@ -68,8 +66,7 @@ void Config::revert_changes(const char* section)
 
 void Config::load_symbols()
 {
-    auto resolve{[this](auto& ptr, const char* name)
-    {
+    auto resolve{[this](auto& ptr, const char* name) {
         ptr = reinterpret_cast<std::remove_reference_t<decltype(ptr)>>(get_symbol(core_, name));
         if(!ptr)
             throw std::system_error(make_error_code(Error::SYM_NOT_FOUND));
@@ -209,7 +206,8 @@ bool ConfigSection::get_bool(const char* param)
 std::string ConfigSection::get_string(const char* param)
 {
     std::string value(STRING_BUF_LEN, '\0');
-    auto ret = fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_STRING, value.data(), (int)value.size());
+    auto ret =
+        fn_.config_get_parameter(section_hdl_, param, param_type_t::M64TYPE_STRING, value.data(), (int)value.size());
 
     if(ret != Error::SUCCESS)
         throw std::system_error(make_error_code(ret));
@@ -219,8 +217,7 @@ std::string ConfigSection::get_string(const char* param)
 
 void ConfigSection::load_symbols()
 {
-    auto resolve{[this](auto& ptr, const char* name)
-    {
+    auto resolve{[this](auto& ptr, const char* name) {
         ptr = reinterpret_cast<std::remove_reference_t<decltype(ptr)>>(get_symbol(core_, name));
         if(!ptr)
             throw std::system_error(make_error_code(Error::SYM_NOT_FOUND));
@@ -237,4 +234,4 @@ void ConfigSection::load_symbols()
     resolve(fn_.config_set_parameter, "ConfigSetParameter");
 }
 
-}
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_config.hpp
+++ b/src/net64/emulator/m64plus_config.hpp
@@ -1,0 +1,125 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#pragma once
+
+#include <string>
+#include <mupen64plus/m64p_types.h>
+#include "net64/emulator/m64plus_error.hpp"
+#include "net64/emulator/shared_library.hpp"
+
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+struct ConfigSection;
+
+struct Config
+{
+    explicit Config(dynlib_t core_lib);
+
+    ConfigSection open_section(const char* name);
+
+    template<typename Fn>
+    void list_sections(const Fn& fn)
+    {
+        auto ret = fn_.config_list_sections(const_cast<Fn*>(&fn), [](void* context, const char* section)
+        {
+            (*reinterpret_cast<const Fn*>(context))(section);
+        });
+
+        if(ret != Error::SUCCESS)
+            throw std::system_error(make_error_code(ret));
+    }
+
+    void save();
+
+    void save(const char* section);
+
+    void delete_section(const char* section);
+
+    bool has_unsaved_changes(const char* section) const;
+
+    void revert_changes(const char* section);
+
+private:
+    void load_symbols();
+
+    dynlib_t core_;
+
+    struct
+    {
+        Error(*config_list_sections)(void*, void(*)(void*, const char*));
+        Error(*config_open_section)(const char*, m64p_handle*);
+        int(*config_has_unsaved_changes)(const char*);
+        Error(*config_delete_section)(const char*);
+        Error(*config_save_file)();
+        Error(*config_save_section)(const char*);
+        Error(*config_revert_changes)(const char*);
+    }fn_{};
+};
+
+struct ConfigSection
+{
+    using cfg_section_hdl_t = m64p_handle;
+    using param_type_t = m64p_type;
+
+    static constexpr std::size_t STRING_BUF_LEN{128};
+
+    ConfigSection(dynlib_t core_lib, cfg_section_hdl_t section_hdl);
+
+    template<typename Fn>
+    void list_parameters(const Fn& fn)
+    {
+        auto ret = fn_.config_list_parameters(const_cast<Fn*>(&fn), [](void* context, const char* name, param_type_t type)
+        {
+            (*reinterpret_cast<const Fn*>(context))(name, type);
+        });
+
+        if(ret != Error::SUCCESS)
+            throw std::system_error(make_error_code(ret));
+    }
+
+    void set_default(const char* param, int value, const char* help_str);
+    void set_default(const char* param, float value, const char* help_str);
+    void set_default(const char* param, bool value, const char* help_str);
+    void set_default(const char* param, const char* value, const char* help_str);
+
+    void set(const char* param, int value);
+    void set(const char* param, float value);
+    void set(const char* param, bool value);
+    void set(const char* param, const char* value);
+
+    const char* help(const char* param);
+    param_type_t type(const char* param);
+
+    int get_int(const char* param);
+    float get_float(const char* param);
+    bool get_bool(const char* param);
+    std::string get_string(const char* param);
+
+private:
+    void load_symbols();
+
+    dynlib_t core_;
+    cfg_section_hdl_t section_hdl_;
+
+    struct
+    {
+        Error(*config_list_parameters)(cfg_section_hdl_t, void*, void(*)(void*, const char*, param_type_t));
+        Error(*config_set_parameter)(m64p_handle, const char*, m64p_type, const void*);
+        Error(*config_get_parameter)(m64p_handle, const char*, m64p_type, void*, int);
+        Error(*config_get_parameter_type)(m64p_handle, const char*, m64p_type*);
+        const char*(*config_get_parameter_help)(m64p_handle, const char*);
+        Error(*config_set_default_int)(m64p_handle, const char*, int, const char*);
+        Error(*config_set_default_float)(m64p_handle, const char*, float, const char*);
+        Error(*config_set_default_bool)(m64p_handle, const char*, int, const char*);
+        Error(*config_set_default_string)(m64p_handle, const char*, const char*, const char*);
+    }fn_{};
+};
+
+}

--- a/src/net64/emulator/m64plus_config.hpp
+++ b/src/net64/emulator/m64plus_config.hpp
@@ -8,14 +8,15 @@
 #pragma once
 
 #include <string>
+
 #include <mupen64plus/m64p_types.h>
+
 #include "net64/emulator/m64plus_error.hpp"
 #include "net64/emulator/shared_library.hpp"
 
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 struct ConfigSection;
 
 struct Config
@@ -27,8 +28,7 @@ struct Config
     template<typename Fn>
     void list_sections(const Fn& fn)
     {
-        auto ret = fn_.config_list_sections(const_cast<Fn*>(&fn), [](void* context, const char* section)
-        {
+        auto ret = fn_.config_list_sections(const_cast<Fn*>(&fn), [](void* context, const char* section) {
             (*reinterpret_cast<const Fn*>(context))(section);
         });
 
@@ -53,14 +53,14 @@ private:
 
     struct
     {
-        Error(*config_list_sections)(void*, void(*)(void*, const char*));
-        Error(*config_open_section)(const char*, m64p_handle*);
-        int(*config_has_unsaved_changes)(const char*);
-        Error(*config_delete_section)(const char*);
-        Error(*config_save_file)();
-        Error(*config_save_section)(const char*);
-        Error(*config_revert_changes)(const char*);
-    }fn_{};
+        Error (*config_list_sections)(void*, void (*)(void*, const char*));
+        Error (*config_open_section)(const char*, m64p_handle*);
+        int (*config_has_unsaved_changes)(const char*);
+        Error (*config_delete_section)(const char*);
+        Error (*config_save_file)();
+        Error (*config_save_section)(const char*);
+        Error (*config_revert_changes)(const char*);
+    } fn_{};
 };
 
 struct ConfigSection
@@ -75,10 +75,10 @@ struct ConfigSection
     template<typename Fn>
     void list_parameters(const Fn& fn)
     {
-        auto ret = fn_.config_list_parameters(const_cast<Fn*>(&fn), [](void* context, const char* name, param_type_t type)
-        {
-            (*reinterpret_cast<const Fn*>(context))(name, type);
-        });
+        auto ret =
+            fn_.config_list_parameters(const_cast<Fn*>(&fn), [](void* context, const char* name, param_type_t type) {
+                (*reinterpret_cast<const Fn*>(context))(name, type);
+            });
 
         if(ret != Error::SUCCESS)
             throw std::system_error(make_error_code(ret));
@@ -110,16 +110,16 @@ private:
 
     struct
     {
-        Error(*config_list_parameters)(cfg_section_hdl_t, void*, void(*)(void*, const char*, param_type_t));
-        Error(*config_set_parameter)(m64p_handle, const char*, m64p_type, const void*);
-        Error(*config_get_parameter)(m64p_handle, const char*, m64p_type, void*, int);
-        Error(*config_get_parameter_type)(m64p_handle, const char*, m64p_type*);
-        const char*(*config_get_parameter_help)(m64p_handle, const char*);
-        Error(*config_set_default_int)(m64p_handle, const char*, int, const char*);
-        Error(*config_set_default_float)(m64p_handle, const char*, float, const char*);
-        Error(*config_set_default_bool)(m64p_handle, const char*, int, const char*);
-        Error(*config_set_default_string)(m64p_handle, const char*, const char*, const char*);
-    }fn_{};
+        Error (*config_list_parameters)(cfg_section_hdl_t, void*, void (*)(void*, const char*, param_type_t));
+        Error (*config_set_parameter)(m64p_handle, const char*, m64p_type, const void*);
+        Error (*config_get_parameter)(m64p_handle, const char*, m64p_type, void*, int);
+        Error (*config_get_parameter_type)(m64p_handle, const char*, m64p_type*);
+        const char* (*config_get_parameter_help)(m64p_handle, const char*);
+        Error (*config_set_default_int)(m64p_handle, const char*, int, const char*);
+        Error (*config_set_default_float)(m64p_handle, const char*, float, const char*);
+        Error (*config_set_default_bool)(m64p_handle, const char*, int, const char*);
+        Error (*config_set_default_string)(m64p_handle, const char*, const char*, const char*);
+    } fn_{};
 };
 
-}
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_core.cpp
+++ b/src/net64/emulator/m64plus_core.cpp
@@ -27,12 +27,6 @@ bool all_true(const TArgs& ... args)
 
 }
 
-const std::vector <std::string> Core::FORBIDDEN_HOTKEYS{
-    "Kbd Mapping Load State", "Kbd Mapping Speed Down",
-    "Kbd Mapping Speed Up", "Kbd Mapping Pause",
-    "Kbd Mapping Fast Forward", "Kbd Mapping Frame Advance",
-    "Kbd Mapping Gameshark"
-};
 
 Core::Core(std::string root_path, std::string data_path)
 :Core(get_current_process(), std::move(root_path), std::move(data_path))
@@ -69,45 +63,9 @@ Core::~Core()
     destroy_core();
 }
 
-void Core::prepare_config_file()
+Config Core::config()
 {
-    list_config_sections(this, [](void* raw_this_ptr, const char* name)
-    {
-        auto this_ptr{reinterpret_cast<Core*>(raw_this_ptr)};
-
-        if(std::strcmp(name, "CoreEvents") == 0)
-        {
-            auto hdl{this_ptr->open_config_section(name)};
-
-            auto clear_param{[this_ptr, hdl](const char* name)
-            {
-                this_ptr->set_config_parameter(hdl, name, M64PTypes::M64TYPE_STRING, "");
-            }};
-
-            for(auto& hotkey : FORBIDDEN_HOTKEYS)
-            {
-                clear_param(hotkey.c_str());
-            }
-        }
-        else if(std::strcmp(name, "Core") == 0)
-        {
-            auto hdl{this_ptr->open_config_section(name)};
-
-            // Enable 8MB
-            auto v{false};
-            this_ptr->set_config_parameter(hdl, "DisableExtraMem", M64PTypes::M64TYPE_BOOL, &v);
-
-            // Screenshot path
-            std::string path{(fs::path(this_ptr->root_path_) / "screenshot").string()};
-            this_ptr->set_config_parameter(hdl, "ScreenshotPath", M64PTypes::M64TYPE_STRING, path.c_str());
-            // Savestate & Savegame path
-            path = (fs::path(this_ptr->root_path_) / "save").string();
-            this_ptr->set_config_parameter(hdl, "SaveStatePath", M64PTypes::M64TYPE_STRING, path.c_str());
-            this_ptr->set_config_parameter(hdl, "SaveSRAMPath", M64PTypes::M64TYPE_STRING, path.c_str());
-        }
-    });
-
-    save_config_file();
+    return Config(handle());
 }
 
 void Core::attach_plugin(Plugin& plugin)
@@ -122,7 +80,7 @@ void Core::attach_plugin(Plugin& plugin)
     }
 }
 
-void Core::detach_plugin(M64PTypes::m64p_plugin_type type)
+void Core::detach_plugin(m64p_plugin_type type)
 {
     auto ret{fn_.core_detach_plugin(type)};
     if(failed(ret))
@@ -135,56 +93,12 @@ void Core::detach_plugin(M64PTypes::m64p_plugin_type type)
 
 volatile void* Core::get_mem_ptr()
 {
-    return fn_.debug_get_mem_ptr(M64PTypes::M64P_DBG_PTR_RDRAM);
+    return fn_.debug_get_mem_ptr(M64P_DBG_PTR_RDRAM);
 }
 
-Error Core::do_cmd(M64PTypes::m64p_command cmd, int p1, void* p2)
+Error Core::do_cmd(m64p_command cmd, int p1, void* p2)
 {
     return fn_.core_do_cmd(cmd, p1, p2);
-}
-
-void Core::list_config_sections(void* context, void (* callback)(void*, const char*))
-{
-    auto ret{fn_.list_config_sections(context, callback)};
-
-    if(failed(ret))
-    {
-        std::system_error err{make_error_code(ret), "Failed to list config sections"};
-        logger()->error(err.what());
-        throw err;
-    }
-}
-
-M64PTypes::m64p_handle Core::open_config_section(const char* name)
-{
-    M64PTypes::m64p_handle hdl;
-
-    auto ret{fn_.open_config_section(name, &hdl)};
-    if(failed(ret))
-    {
-        std::system_error err{make_error_code(ret), "Failed to open config section " + std::string(name)};
-        logger()->error(err.what());
-        throw err;
-    }
-
-    return hdl;
-}
-
-void Core::save_config_file()
-{
-    return fn_.save_config_file();
-}
-
-void Core::set_config_parameter(M64PTypes::m64p_handle handle, const char* param_name, M64PTypes::m64p_type type,
-                                const void* data)
-{
-    auto ret{fn_.set_config_parameter(handle, param_name, type, data)};
-    if(failed(ret))
-    {
-        std::system_error err{make_error_code(ret), "Failed to set config parameter " + std::string(param_name)};
-        logger()->error(err.what());
-        throw err;
-    }
 }
 
 void Core::set_state_callback(state_callback_f cb) noexcept
@@ -206,14 +120,9 @@ void Core::init_symbols()
     resolve_symbol(fn_.core_detach_plugin, "CoreDetachPlugin");
     resolve_symbol(fn_.core_do_cmd, "CoreDoCommand");
     resolve_symbol(fn_.debug_get_mem_ptr, "DebugMemGetPointer");
-    resolve_symbol(fn_.list_config_sections, "ConfigListSections");
-    resolve_symbol(fn_.open_config_section, "ConfigOpenSection");
-    resolve_symbol(fn_.save_config_file, "ConfigSaveFile");
-    resolve_symbol(fn_.set_config_parameter, "ConfigSetParameter");
 
     if(!all_true(fn_.plugin_get_version, fn_.core_attach_plugin, fn_.core_detach_plugin, fn_.core_startup,
-                 fn_.core_shutdown, fn_.core_do_cmd, fn_.debug_get_mem_ptr, fn_.list_config_sections,
-                 fn_.open_config_section, fn_.save_config_file, fn_.set_config_parameter))
+                 fn_.core_shutdown, fn_.core_do_cmd, fn_.debug_get_mem_ptr))
     {
         std::system_error err{make_error_code(Error::SYM_NOT_FOUND), "Failed to resolve core symbole"};
         logger()->error(err.what());
@@ -280,10 +189,10 @@ void Core::destroy_core()
         auto errc{make_error_code(ret)};
         logger()->warn("Failed to correctly shutdown core: ", errc.message());
     }
-    logger()->info("Shutdown {}", Plugin::type_str(M64PTypes::M64PLUGIN_CORE));
+    logger()->info("Shutdown {}", Plugin::type_str(M64PLUGIN_CORE));
 }
 
-void Core::state_callback_c(void* context, M64PTypes::m64p_core_param param_type, int new_value)
+void Core::state_callback_c(void* context, m64p_core_param param_type, int new_value)
 {
     auto cb = reinterpret_cast<state_callback_f*>(context);
     if (*cb)

--- a/src/net64/emulator/m64plus_core.hpp
+++ b/src/net64/emulator/m64plus_core.hpp
@@ -1,0 +1,141 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#pragma once
+
+#include "net64/emulator/m64plus_config.hpp"
+#include "net64/emulator/m64plus_error.hpp"
+#include "net64/emulator/shared_library.hpp"
+#include "net64/logging.hpp"
+
+
+namespace Net64::Emulator
+{
+
+struct Mupen64Plus;
+
+}
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+class Plugin;
+
+/// Contains information retrieved via PluginGetVersion
+struct PluginInfo
+{
+    m64p_plugin_type type{M64PLUGIN_NULL};
+    int plugin_version{},
+        api_version{},
+        capabilities{};
+    std::string name;
+};
+
+/**
+ * Dynamically loaded Mupen64Plus core
+ */
+class Core final
+{
+    friend struct ::Net64::Emulator::Mupen64Plus;
+    friend class ::Net64::Emulator::M64PlusHelper::Plugin;
+
+    // Function pointer types
+    using plugin_get_version_t = Error(CALL*)(m64p_plugin_type*, int*, int*, const char**, int*);
+    using debug_context_t = void*;
+    using debug_callback_t = void(*)(void*, int, const char*);
+    using state_context_t = void*;
+    using state_callback_t = void(*)(void*, m64p_core_param, int);
+    using core_startup_t = Error(CALL*)(int, const char*, const char*,
+    debug_context_t, debug_callback_t,
+    state_context_t, state_callback_t);
+    using core_shutdown_t = Error(CALL*)();
+    using core_attach_plugin_t = Error(CALL*)(m64p_plugin_type, m64p_dynlib_handle);
+    using core_detach_plugin_t = Error(CALL*)(m64p_plugin_type);
+    using core_do_cmd_t = Error(CALL*)(m64p_command, int, void*);
+    using debug_get_mem_ptr_t = volatile void* (CALL*)(m64p_dbg_memptr_type);
+
+    using state_callback_f = std::function<void(m64p_core_param, int)>;
+    using debug_callback_f = std::function<void(int, const char*)>;
+
+    /// Mupen64Plus API this frontend is compatible with
+    static constexpr int API_VERSION{0x020001};
+
+    /// Create core from current process
+    Core(std::string root_path, std::string data_path);
+
+    /// Create core from dynamic library handle
+    Core(dynlib_t lib, std::string root_path, std::string data_path);
+
+    /// Create core from library file
+    Core(const std::string& lib_path, std::string root_path, std::string data_path);
+
+    /// Non copyable
+    Core(const Core&) = delete;
+
+    /// Non movable
+    Core(Core&& other) = delete;
+
+    ~Core();
+
+    // @todo:
+public:
+    Config config();
+private:
+
+    void attach_plugin(Plugin& plugin);
+
+    void detach_plugin(m64p_plugin_type type);
+
+    /// Return pointer to n64 DRAM
+    volatile void* get_mem_ptr();
+
+    Error do_cmd(m64p_command cmd, int p1, void* p2);
+
+    void set_state_callback(state_callback_f cb) noexcept;
+    void set_debug_callback(debug_callback_f cb) noexcept;
+
+    /// Return native library handle
+    dynlib_t handle();
+
+    /// Return general information about the core
+    const PluginInfo& info() const;
+
+    void init_symbols();
+    void init_core();
+    void create_folder_structure();
+    void destroy_core();
+
+    static void state_callback_c(void* context, m64p_core_param param_type, int new_value);
+    static void debug_callback_c(void* context, int level, const char* message);
+
+    template<typename T>
+    void resolve_symbol(T& fn_ptr, const char* name)
+    {
+        fn_ptr = reinterpret_cast<T>(get_symbol(handle_.lib, name));
+    }
+
+    UniqueLib handle_{};
+    struct CoreFunctions
+    {
+        plugin_get_version_t plugin_get_version;
+        core_startup_t core_startup;
+        core_shutdown_t core_shutdown;
+        core_attach_plugin_t core_attach_plugin;
+        core_detach_plugin_t core_detach_plugin;
+        core_do_cmd_t core_do_cmd;
+        debug_get_mem_ptr_t debug_get_mem_ptr;
+    }fn_{};
+    PluginInfo info_;
+    std::unique_ptr<state_callback_f> state_callback_ = std::make_unique<state_callback_f>();
+    std::unique_ptr<debug_callback_f> debug_callback_ = std::make_unique<debug_callback_f>();
+
+    std::string root_path_, data_path_;
+
+    CLASS_LOGGER_("mupen64plus");
+};
+
+} // Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_core.hpp
+++ b/src/net64/emulator/m64plus_core.hpp
@@ -15,23 +15,19 @@
 
 namespace Net64::Emulator
 {
-
 struct Mupen64Plus;
 
 }
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 class Plugin;
 
 /// Contains information retrieved via PluginGetVersion
 struct PluginInfo
 {
     m64p_plugin_type type{M64PLUGIN_NULL};
-    int plugin_version{},
-        api_version{},
-        capabilities{};
+    int plugin_version{}, api_version{}, capabilities{};
     std::string name;
 };
 
@@ -46,17 +42,16 @@ class Core final
     // Function pointer types
     using plugin_get_version_t = Error(CALL*)(m64p_plugin_type*, int*, int*, const char**, int*);
     using debug_context_t = void*;
-    using debug_callback_t = void(*)(void*, int, const char*);
+    using debug_callback_t = void (*)(void*, int, const char*);
     using state_context_t = void*;
-    using state_callback_t = void(*)(void*, m64p_core_param, int);
-    using core_startup_t = Error(CALL*)(int, const char*, const char*,
-    debug_context_t, debug_callback_t,
-    state_context_t, state_callback_t);
+    using state_callback_t = void (*)(void*, m64p_core_param, int);
+    using core_startup_t = Error(CALL*)(
+        int, const char*, const char*, debug_context_t, debug_callback_t, state_context_t, state_callback_t);
     using core_shutdown_t = Error(CALL*)();
     using core_attach_plugin_t = Error(CALL*)(m64p_plugin_type, m64p_dynlib_handle);
     using core_detach_plugin_t = Error(CALL*)(m64p_plugin_type);
     using core_do_cmd_t = Error(CALL*)(m64p_command, int, void*);
-    using debug_get_mem_ptr_t = volatile void* (CALL*)(m64p_dbg_memptr_type);
+    using debug_get_mem_ptr_t = volatile void*(CALL*)(m64p_dbg_memptr_type);
 
     using state_callback_f = std::function<void(m64p_core_param, int)>;
     using debug_callback_f = std::function<void(int, const char*)>;
@@ -84,8 +79,8 @@ class Core final
     // @todo:
 public:
     Config config();
-private:
 
+private:
     void attach_plugin(Plugin& plugin);
 
     void detach_plugin(m64p_plugin_type type);
@@ -128,7 +123,7 @@ private:
         core_detach_plugin_t core_detach_plugin;
         core_do_cmd_t core_do_cmd;
         debug_get_mem_ptr_t debug_get_mem_ptr;
-    }fn_{};
+    } fn_{};
     PluginInfo info_;
     std::unique_ptr<state_callback_f> state_callback_ = std::make_unique<state_callback_f>();
     std::unique_ptr<debug_callback_f> debug_callback_ = std::make_unique<debug_callback_f>();
@@ -138,4 +133,4 @@ private:
     CLASS_LOGGER_("mupen64plus");
 };
 
-} // Net64::Emulator::M64PlusHelper
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_error.cpp
+++ b/src/net64/emulator/m64plus_error.cpp
@@ -9,13 +9,9 @@
 
 namespace
 {
-
 const struct M64PlusErrorCategory : std::error_category
 {
-    const char* name() const noexcept override
-    {
-        return "mupen64plus";
-    }
+    const char* name() const noexcept override { return "mupen64plus"; }
     std::string message(int ev) const override
     {
         using Net64::Emulator::M64PlusHelper::Error;
@@ -61,16 +57,15 @@ const struct M64PlusErrorCategory : std::error_category
             return "[Unknown Error]";
         }
     }
-}m64p_error_category_g;
+} m64p_error_category_g;
 
-} // anonymous
+} // namespace
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 std::error_code make_error_code(Error e) noexcept
 {
     return {static_cast<int>(e), m64p_error_category_g};
 }
 
-} // Net64::Emulator::M64PlusHelper
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_error.cpp
+++ b/src/net64/emulator/m64plus_error.cpp
@@ -1,0 +1,76 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#include "net64/emulator/m64plus_error.hpp"
+
+namespace
+{
+
+const struct M64PlusErrorCategory : std::error_category
+{
+    const char* name() const noexcept override
+    {
+        return "mupen64plus";
+    }
+    std::string message(int ev) const override
+    {
+        using Net64::Emulator::M64PlusHelper::Error;
+
+        switch(static_cast<Error>(ev))
+        {
+        case Error::NOT_INIT:
+            return "Function is disallowed before InitMupen64Plus() is called";
+        case Error::ALREADY_INIT:
+            return "InitMupen64Plus() was called twice";
+        case Error::INCOMPATIBLE:
+            return "API versions between components are incompatible";
+        case Error::INPUT_ASSERT:
+            return "Invalid parameters for function call";
+        case Error::INPUT_INVALID:
+            return "Invalid input data";
+        case Error::INPUT_NOT_FOUND:
+            return "The input parameter(s) specified a particular item which was not found";
+        case Error::NO_MEMORY:
+            return "Memory allocation failed";
+        case Error::FILES:
+            return "Error opening, creating, reading, or writing to a file";
+        case Error::INTERNAL:
+            return "Internal error (bug)";
+        case Error::INVALID_STATE:
+            return "Current program state does not allow operation";
+        case Error::PLUGIN_FAIL:
+            return "A plugin function returned a fatal error";
+        case Error::SYSTEM_FAIL:
+            return "A system function call, such as an SDL or file operation, failed";
+        case Error::UNSUPPORTED:
+            return "Function call is not supported";
+        case Error::WRONG_TYPE:
+            return "A given input type parameter cannot be used for desired operation";
+
+        case Error::LIB_LOAD_FAILED:
+            return "Failed to load library file";
+        case Error::INVALID_ADDR:
+            return "Tried to access out of bounds memory";
+        case Error::SYM_NOT_FOUND:
+            return "A symbol required by the API could not be located in the specified module";
+        default:
+            return "[Unknown Error]";
+        }
+    }
+}m64p_error_category_g;
+
+} // anonymous
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+std::error_code make_error_code(Error e) noexcept
+{
+    return {static_cast<int>(e), m64p_error_category_g};
+}
+
+} // Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_error.hpp
+++ b/src/net64/emulator/m64plus_error.hpp
@@ -1,0 +1,45 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#pragma once
+
+#include <system_error>
+#include <mupen64plus/m64p_types.h>
+
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+/// Mupen64Plus error codes
+enum struct Error
+{
+    // Mupen64Plus internal errors
+    SUCCESS = 0,
+    NOT_INIT,        ///< Function is disallowed before InitMupen64Plus() is called
+    ALREADY_INIT,    ///< InitMupen64Plus() was called twice
+    INCOMPATIBLE,    ///< API versions between components are incompatible
+    INPUT_ASSERT,    ///< Invalid parameters for function call, such as ParamValue=NULL for GetCoreParameter()
+    INPUT_INVALID,   ///< Invalid input data, such as ParamValue="maybe" for SetCoreParameter() to set a BOOL-type value
+    INPUT_NOT_FOUND, ///< The input parameter(s) specified a particular item which was not found
+    NO_MEMORY,       ///< Memory allocation failed
+    FILES,           ///< Error opening, creating, reading, or writing to a file
+    INTERNAL,        ///< Internal error (bug)
+    INVALID_STATE,   ///< Current program state does not allow operation
+    PLUGIN_FAIL,     ///< A plugin function returned a fatal error
+    SYSTEM_FAIL,     ///< A system function call, such as an SDL or file operation, failed
+    UNSUPPORTED,     ///< Function call is not supported (ie, core not built with debugger)
+    WRONG_TYPE,      ///< A given input type parameter cannot be used for desired operation
+    // Interface errors
+    LIB_LOAD_FAILED, ///< Failed to load library file
+    INVALID_ADDR,    ///< Tried to access out of bounds memory
+    SYM_NOT_FOUND    ///< A symbol required by the API could not be located in the specified module
+};
+
+/// Overload for Mupen64Plus error codes
+std::error_code make_error_code(Error e) noexcept;
+
+}

--- a/src/net64/emulator/m64plus_error.hpp
+++ b/src/net64/emulator/m64plus_error.hpp
@@ -8,12 +8,12 @@
 #pragma once
 
 #include <system_error>
+
 #include <mupen64plus/m64p_types.h>
 
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 /// Mupen64Plus error codes
 enum struct Error
 {
@@ -33,7 +33,7 @@ enum struct Error
     SYSTEM_FAIL,     ///< A system function call, such as an SDL or file operation, failed
     UNSUPPORTED,     ///< Function call is not supported (ie, core not built with debugger)
     WRONG_TYPE,      ///< A given input type parameter cannot be used for desired operation
-    // Interface errors
+                     // Interface errors
     LIB_LOAD_FAILED, ///< Failed to load library file
     INVALID_ADDR,    ///< Tried to access out of bounds memory
     SYM_NOT_FOUND    ///< A symbol required by the API could not be located in the specified module
@@ -42,4 +42,4 @@ enum struct Error
 /// Overload for Mupen64Plus error codes
 std::error_code make_error_code(Error e) noexcept;
 
-}
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_plugin.cpp
+++ b/src/net64/emulator/m64plus_plugin.cpp
@@ -10,38 +10,34 @@
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 namespace
 {
-
 bool failed(Mupen64Plus::Error err)
 {
     return err != Mupen64Plus::Error::SUCCESS;
 }
 
 template<typename... TArgs>
-bool all_true(const TArgs& ... args)
+bool all_true(const TArgs&... args)
 {
     return (args && ...);
 }
 
-}
+} // namespace
 
-Plugin::Plugin(Core& core, dynlib_t lib)
-:handle_{lib}
+Plugin::Plugin(Core& core, dynlib_t lib): handle_{lib}
 {
     init_symbols();
     init_plugin(core.handle());
 }
 
-Plugin::Plugin(Core& core, const std::string& lib_path)
-:handle_{load_library(lib_path.c_str())}
+Plugin::Plugin(Core& core, const std::string& lib_path): handle_{load_library(lib_path.c_str())}
 {
     if(!handle_.lib)
     {
         // Library file does not exist
-        std::system_error err(make_error_code(Error::LIB_LOAD_FAILED), "Failed to load plugin library file " +
-                              std::string(get_lib_error_msg()));
+        std::system_error err(make_error_code(Error::LIB_LOAD_FAILED),
+                              "Failed to load plugin library file " + std::string(get_lib_error_msg()));
         logger()->error(err.what());
         throw err;
     }
@@ -151,8 +147,12 @@ void Plugin::init_plugin(dynlib_t core_lib)
         // Plugin failed to initialize
         auto errc{make_error_code(ret)};
         logger()->error("Failed to start {} plugin {} v{}, api: {} (capabilities: {:#x}): {}",
-                        Plugin::type_str(info_.type), name_ptr, info_.plugin_version, info_.api_version,
-                        info_.capabilities, errc.message());
+                        Plugin::type_str(info_.type),
+                        name_ptr,
+                        info_.plugin_version,
+                        info_.api_version,
+                        info_.capabilities,
+                        errc.message());
         info_ = {};
         throw std::system_error(errc, "Failed to start " + std::string(Plugin::type_str(info_.type)) + " plugin");
     }
@@ -160,7 +160,11 @@ void Plugin::init_plugin(dynlib_t core_lib)
     info_.name = name_ptr;
 
     logger()->info("Initialized {} plugin {} v{}, api: {:#x} (capabilities: {:#x})",
-                   Plugin::type_str(info_.type), name_ptr, info_.plugin_version, info_.api_version, info_.capabilities);
+                   Plugin::type_str(info_.type),
+                   name_ptr,
+                   info_.plugin_version,
+                   info_.api_version,
+                   info_.capabilities);
 }
 
 void Plugin::destroy_plugin()
@@ -176,4 +180,4 @@ void Plugin::destroy_plugin()
     logger()->info("Shutdown {} plugin", Plugin::type_str(info_.type));
 }
 
-} // Net64::Emulator::M64PlusHelper
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/net64/emulator/m64plus_plugin.cpp
+++ b/src/net64/emulator/m64plus_plugin.cpp
@@ -96,10 +96,8 @@ PluginInfo Plugin::get_plugin_info(dynlib_t lib)
     return info;
 }
 
-const char* Plugin::type_str(M64PTypes::m64p_plugin_type type_id)
+const char* Plugin::type_str(m64p_plugin_type type_id)
 {
-    using namespace M64PTypes;
-
     switch(type_id)
     {
     case M64PLUGIN_RSP:

--- a/src/net64/emulator/m64plus_plugin.hpp
+++ b/src/net64/emulator/m64plus_plugin.hpp
@@ -1,0 +1,85 @@
+//
+// Created by henrik on 10.02.20.
+// Copyright 2020 Net64 Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included.
+//
+
+#pragma once
+
+#include "net64/emulator/m64plus_core.hpp"
+
+
+namespace Net64::Emulator::M64PlusHelper
+{
+
+/**
+ * Dynamically loaded Mupen64Plus plugin
+ */
+class Plugin final
+{
+    friend struct ::Net64::Emulator::Mupen64Plus;
+    friend class ::Net64::Emulator::M64PlusHelper::Core;
+
+public:
+    /// Non copyable
+    Plugin(const Plugin&) = delete;
+
+    /// Non movable
+    Plugin(Plugin&& other) = delete;
+
+    ~Plugin();
+
+    /**
+     * Load file as plugin and return information about it.
+     * Returns type = M64PLUGIN_NULL if not a plugin
+     */
+    static PluginInfo get_plugin_info(const std::string& file);
+    static PluginInfo get_plugin_info(dynlib_t lib);
+
+    /// Get string representation of plugin type id
+    static const char* type_str(m64p_plugin_type type_id);
+
+private:
+    // Function pointer types
+    using plugin_startup_t = Error(CALL*)(m64p_dynlib_handle, void*, void* (*)(void*, int, const char*));
+    using plugin_shutdown_t = Error(CALL*)();
+    using plugin_get_version_t = Error(CALL*)(m64p_plugin_type*, int*, int*, const char**, int*);
+
+    /// Create plugin from dynamic library handle
+    Plugin(Core& core, dynlib_t lib);
+
+    /// Create plugin from library path
+    Plugin(Core& core, const std::string& lib_path);
+
+    /// Return general information about the plugin
+    const PluginInfo& info() const;
+
+    /// Return native library handle
+    dynlib_t handle();
+
+    void init_symbols();
+    void init_plugin(dynlib_t core_lib);
+    void destroy_plugin();
+
+    template<typename T>
+    void resolve_symbol(T& fn_ptr, const char* name)
+    {
+        fn_ptr = reinterpret_cast<T>(get_symbol(handle_.lib, name));
+    }
+
+    UniqueLib handle_{};
+    struct
+    {
+        plugin_startup_t startup;
+        plugin_shutdown_t shutdown;
+        plugin_get_version_t get_version;
+    }fn_{};
+    PluginInfo info_;
+
+    CLASS_LOGGER_("mupen64plus");
+};
+
+#undef CALL
+
+} // M64PlusHelper

--- a/src/net64/emulator/m64plus_plugin.hpp
+++ b/src/net64/emulator/m64plus_plugin.hpp
@@ -12,7 +12,6 @@
 
 namespace Net64::Emulator::M64PlusHelper
 {
-
 /**
  * Dynamically loaded Mupen64Plus plugin
  */
@@ -74,7 +73,7 @@ private:
         plugin_startup_t startup;
         plugin_shutdown_t shutdown;
         plugin_get_version_t get_version;
-    }fn_{};
+    } fn_{};
     PluginInfo info_;
 
     CLASS_LOGGER_("mupen64plus");
@@ -82,4 +81,4 @@ private:
 
 #undef CALL
 
-} // M64PlusHelper
+} // namespace Net64::Emulator::M64PlusHelper

--- a/src/qt_gui/CMakeLists.txt
+++ b/src/qt_gui/CMakeLists.txt
@@ -19,7 +19,22 @@ add_executable(net64_qt_gui
                 patch_dialog.hpp
                 patch_dialog.cpp
                 net64_thread.hpp
-                net64_thread.cpp)
+                net64_thread.cpp
+                emulatorsettings.cpp
+                emulatorsettings.hpp
+                emulator_audio_configuration.hpp
+                emulator_audio_configuration.cpp
+                emulator_video_configuration.hpp
+                emulator_video_configuration.cpp
+                emulator_controller_configuration.cpp
+                emulator_controller_configuration.hpp
+                ../common/sdl_event_handler.cpp
+                ../common/sdl_event_handler.hpp
+                sdl_bind_button.cpp
+                sdl_bind_button.hpp
+        )
+
+target_compile_options(net64_qt_gui PRIVATE ${ADDITIONAL_CXXFLAGS})
 
 target_link_libraries(net64_qt_gui net64_core)
 
@@ -35,6 +50,10 @@ target_include_directories(net64_qt_gui PRIVATE "${JSON_INCLUDES}")
 # vcdiff library
 target_link_libraries(net64_qt_gui vcddec vcdenc)
 target_include_directories(net64_qt_gui PRIVATE "${PROJECT_SOURCE_DIR}/externals/open-vcdiff/src")
+
+include(SDL2_finder)
+requires_sdl2()
+target_link_libraries(net64_qt_gui SDL2::SDL2)
 
 if(UNIX)
     target_link_libraries(net64_qt_gui -lpthread -lstdc++fs)

--- a/src/qt_gui/emulator_audio_configuration.cpp
+++ b/src/qt_gui/emulator_audio_configuration.cpp
@@ -4,15 +4,12 @@
 
 namespace Frontend
 {
-
 EmulatorAudioConfiguration::EmulatorAudioConfiguration(QWidget* parent):
-    QWidget(parent),
-    ui(new Ui::EmulatorAudioConfiguration)
+    QWidget(parent), ui(new Ui::EmulatorAudioConfiguration)
 {
     ui->setupUi(this);
 
-    connect(ui->volume_slider, &QSlider::valueChanged, [this](int position)
-    {
+    connect(ui->volume_slider, &QSlider::valueChanged, [this](int position) {
         ui->volume_percentage_lbl->setText(QString::fromStdString(std::to_string(position) + "%"));
 
         if(audio_settings_)
@@ -64,4 +61,4 @@ void EmulatorAudioConfiguration::load_settings()
     ui->volume_slider->setValue(static_cast<int>(volume * 100));
 }
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/emulator_audio_configuration.cpp
+++ b/src/qt_gui/emulator_audio_configuration.cpp
@@ -1,0 +1,67 @@
+#include "emulator_audio_configuration.hpp"
+#include "ui_emulator_audio_configuration.h"
+
+
+namespace Frontend
+{
+
+EmulatorAudioConfiguration::EmulatorAudioConfiguration(QWidget* parent):
+    QWidget(parent),
+    ui(new Ui::EmulatorAudioConfiguration)
+{
+    ui->setupUi(this);
+
+    connect(ui->volume_slider, &QSlider::valueChanged, [this](int position)
+    {
+        ui->volume_percentage_lbl->setText(QString::fromStdString(std::to_string(position) + "%"));
+
+        if(audio_settings_)
+            audio_settings_->set_volume(static_cast<float>(position) / 100);
+    });
+
+    update_interface();
+}
+
+EmulatorAudioConfiguration::~EmulatorAudioConfiguration()
+{
+    delete ui;
+}
+
+void EmulatorAudioConfiguration::set_settings_handle(Net64::Emulator::IAudioSettings* settings)
+{
+    audio_settings_.reset(settings);
+
+    update_interface();
+}
+
+bool EmulatorAudioConfiguration::has_settings_handle() const
+{
+    return (audio_settings_ != nullptr);
+}
+
+void EmulatorAudioConfiguration::update_interface()
+{
+    if(!audio_settings_)
+    {
+        ui->volume_box->setHidden(true);
+        return;
+    }
+
+    float volume{};
+    ui->volume_box->setHidden(!audio_settings_->get_volume(volume));
+    ui->volume_box->setDisabled(!audio_settings_->set_volume(volume));
+
+    load_settings();
+}
+
+void EmulatorAudioConfiguration::load_settings()
+{
+    if(!audio_settings_)
+        return;
+
+    float volume{};
+    audio_settings_->get_volume(volume);
+    ui->volume_slider->setValue(static_cast<int>(volume * 100));
+}
+
+} // Frontend

--- a/src/qt_gui/emulator_audio_configuration.hpp
+++ b/src/qt_gui/emulator_audio_configuration.hpp
@@ -1,0 +1,39 @@
+﻿#pragma once
+
+#include <QWidget>
+
+#ifndef Q_MOC_RUN
+#include "net64/emulator/emulator.hpp"
+#endif
+
+
+namespace Ui {
+class EmulatorAudioConfiguration;
+}
+
+
+namespace Frontend
+{
+
+struct EmulatorAudioConfiguration : QWidget
+{
+Q_OBJECT
+
+public:
+    explicit EmulatorAudioConfiguration(QWidget* parent = nullptr);
+    ~EmulatorAudioConfiguration() override;
+
+public slots:
+    void set_settings_handle(Net64::Emulator::IAudioSettings* settings);
+
+    bool has_settings_handle() const;
+
+private:
+    void update_interface();
+    void load_settings();
+
+    Ui::EmulatorAudioConfiguration* ui;
+    std::unique_ptr<Net64::Emulator::IAudioSettings> audio_settings_;
+};
+
+} // Frontend

--- a/src/qt_gui/emulator_audio_configuration.hpp
+++ b/src/qt_gui/emulator_audio_configuration.hpp
@@ -2,22 +2,20 @@
 
 #include <QWidget>
 
-#ifndef Q_MOC_RUN
 #include "net64/emulator/emulator.hpp"
-#endif
 
 
-namespace Ui {
+namespace Ui
+{
 class EmulatorAudioConfiguration;
 }
 
 
 namespace Frontend
 {
-
 struct EmulatorAudioConfiguration : QWidget
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
     explicit EmulatorAudioConfiguration(QWidget* parent = nullptr);
@@ -36,4 +34,4 @@ private:
     std::unique_ptr<Net64::Emulator::IAudioSettings> audio_settings_;
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/emulator_audio_configuration.ui
+++ b/src/qt_gui/emulator_audio_configuration.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EmulatorAudioConfiguration</class>
+ <widget class="QWidget" name="EmulatorAudioConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>136</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>305</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="volume_box">
+     <property name="title">
+      <string>Volume</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QSlider" name="volume_slider">
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>50</number>
+        </property>
+        <property name="sliderPosition">
+         <number>50</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="invertedAppearance">
+         <bool>false</bool>
+        </property>
+        <property name="invertedControls">
+         <bool>false</bool>
+        </property>
+        <property name="tickPosition">
+         <enum>QSlider::TicksBothSides</enum>
+        </property>
+        <property name="tickInterval">
+         <number>25</number>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="volume_percentage_lbl">
+        <property name="text">
+         <string>50%</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt_gui/emulator_controller_configuration.cpp
+++ b/src/qt_gui/emulator_controller_configuration.cpp
@@ -1,0 +1,284 @@
+﻿#include "emulator_controller_configuration.hpp"
+#include "ui_emulator_controller_configuration.h"
+
+namespace Frontend
+{
+
+using namespace Net64::Emulator;
+
+EmulatorControllerConfiguration::EmulatorControllerConfiguration(QWidget* parent):
+    QWidget(parent),
+    ui(new Ui::EmulatorControllerConfiguration)
+{
+    ui->setupUi(this);
+
+    ui->pak_box->addItem(IControllerSettings::pak_to_string(ControllerPak::NONE));
+    ui->pak_box->addItem(IControllerSettings::pak_to_string(ControllerPak::RUMBLE_PAK));
+    ui->pak_box->addItem(IControllerSettings::pak_to_string(ControllerPak::MEM_PAK));
+
+    ui->mode_box->addItem(IControllerSettings::config_mode_to_string(ConfigurationMode::AUTOMATIC));
+    ui->mode_box->addItem(IControllerSettings::config_mode_to_string(ConfigurationMode::AUTO_NAMED_SDL_DEV));
+    ui->mode_box->addItem(IControllerSettings::config_mode_to_string(ConfigurationMode::MANUAL));
+
+    connect(ui->mode_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
+    {
+        if(!controller_settings_)
+            return;
+
+        controller_settings_->set_config_mode(IControllerSettings::config_mode_from_string(ui->mode_box->currentText().toStdString()).value());
+        update_interface();
+    });
+
+    connect(ui->pak_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
+    {
+        if(!controller_settings_)
+            return;
+
+        controller_settings_->set_pak(IControllerSettings::pak_from_string(ui->pak_box->currentText().toStdString()).value());
+    });
+
+    connect(ui->device_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
+    {
+        if(!controller_settings_ || ui->device_box->count() < 2)
+            return;
+
+        for(auto& btn : sdl_bind_buttons_)
+        {
+            btn->set_keyboard();
+        }
+
+        auto selected_dev{ui->device_box->currentText()};
+
+        if(selected_dev == "[Disconnected]")
+        {
+            return;
+        }
+        else if(selected_dev == "Keyboard")
+        {
+            // Keyboard selected
+            controller_settings_->set_device("Keyboard", -1);
+
+            joystick_.reset();
+        }
+        else
+        {
+            // Gamepad selected
+            auto joy_idx{ui->device_box->currentIndex() - 1};
+
+            assert(joy_idx >= 0);
+
+            joystick_.reset(SDL_JoystickOpen(joy_idx));
+
+            if(!joystick_)
+            {
+                logger()->error("Failed to open joystick {}:{}: {}",
+                                ui->device_box->currentText().toStdString(), joy_idx, SDL_GetError());
+                return;
+            }
+
+            controller_settings_->set_device(ui->device_box->currentText().toStdString(), joy_idx);
+
+            for(auto& btn : sdl_bind_buttons_)
+            {
+                btn->set_joystick(SDL_JoystickInstanceID(joystick_.get()));
+            }
+        }
+
+        // Remove disconnected device item
+        int disconnected_idx{ui->device_box->findText("[Disconnected]")};
+        if(disconnected_idx > -1)
+        {
+            ui->device_box->removeItem(disconnected_idx);
+        }
+    });
+
+    setup_sdl_buttons();
+}
+
+EmulatorControllerConfiguration::~EmulatorControllerConfiguration()
+{
+    delete ui;
+}
+
+void EmulatorControllerConfiguration::set_settings_handle(Net64::Emulator::IControllerSettings* settings)
+{
+    controller_settings_.reset(settings);
+
+    for(auto& btn : sdl_bind_buttons_)
+    {
+        btn->set_settings_handle(settings);
+    }
+
+    update_interface();
+}
+
+bool EmulatorControllerConfiguration::has_settings_handle() const
+{
+    return bool(controller_settings_);
+}
+
+void EmulatorControllerConfiguration::handle_sdl_event(const SDL_Event &event)
+{
+    switch(event.type)
+    {
+    case SDL_JOYDEVICEADDED:
+        [[fallthrough]];
+    case SDL_JOYDEVICEREMOVED:
+        scan_devices();
+        break;
+    }
+}
+
+void EmulatorControllerConfiguration::scan_devices()
+{
+    auto set_combobox = [](QComboBox& box, const std::string& str)
+    {
+        box.setCurrentText(QString::fromStdString(str));
+    };
+
+    if(!controller_settings_)
+        return;
+
+    // Load configured device
+    std::string device_name;
+    int device_idx;
+    controller_settings_->get_device(device_name, device_idx);
+    device_name.resize(std::strlen(device_name.c_str()));
+
+    ui->device_box->clear();
+
+    ui->device_box->addItem("Keyboard");
+
+    for(int i{}; i < SDL_NumJoysticks(); ++i)
+    {
+        std::string name{SDL_JoystickNameForIndex(i)};
+
+        if(!name.empty())
+            ui->device_box->addItem(name.c_str());
+    }
+
+    set_combobox(*ui->device_box, device_name);
+    if(ui->device_box->findText(QString::fromStdString(device_name)) <= -1)
+    {
+        // Configured device is not connected
+        ui->device_box->addItem("[Disconnected]");
+        set_combobox(*ui->device_box, "[Disconnected]");
+    }
+}
+
+void EmulatorControllerConfiguration::update_interface()
+{
+    ui->device_box->setHidden(!controller_settings_);
+    ui->buttons_box->setHidden(!controller_settings_);
+    ui->analog_stick_box->setHidden(!controller_settings_);
+    ui->c_box->setHidden(!controller_settings_);
+    ui->d_pad_box->setHidden(!controller_settings_);
+
+    if(!controller_settings_)
+        return;
+
+    std::string tmp_str;
+    int tmp_int{};
+    float tmp_float{};
+    sdl_input_t sdl_input{};
+    ControllerPak tmp_pak{};
+    ConfigurationMode tmp_mode{};
+
+    ui->device_box->setHidden(!controller_settings_->get_device(tmp_str, tmp_int));
+    ui->device_box->setDisabled(!controller_settings_->set_device(tmp_str, tmp_int));
+    ui->pak_box->setHidden(!controller_settings_->get_pak(tmp_pak));
+    ui->pak_box->setDisabled(!controller_settings_->set_pak(tmp_pak));
+    ui->mode_box->setHidden(!controller_settings_->get_config_mode(tmp_mode));
+    ui->mode_box->setDisabled(!controller_settings_->set_config_mode(tmp_mode));
+    ui->deadzone_sbx->setHidden(!controller_settings_->get_analog_deadzone(tmp_float));
+    ui->deadzone_sbx->setDisabled(!controller_settings_->set_analog_deadzone(tmp_float));
+    ui->peak_sbx->setHidden(!controller_settings_->get_analog_peak(tmp_float));
+    ui->peak_sbx->setDisabled(!controller_settings_->set_analog_peak(tmp_float));
+
+    bool read_mappings{controller_settings_->get_bind(N64Button::START, sdl_input)};
+    bool set_mappings{controller_settings_->set_bind(N64Button::START, sdl_input)};
+    ui->c_box->setHidden(!read_mappings);
+    ui->analog_stick_box->setHidden(!read_mappings);
+    ui->buttons_box->setHidden(!read_mappings);
+    ui->d_pad_box->setHidden(!read_mappings);
+
+    ui->c_box->setDisabled(!set_mappings);
+    ui->analog_stick_box->setDisabled(!set_mappings);
+    ui->buttons_box->setDisabled(!set_mappings);
+    ui->d_pad_box->setDisabled(!set_mappings);
+
+    load_settings();
+}
+
+void EmulatorControllerConfiguration::load_settings()
+{
+    if(!controller_settings_)
+        return;
+
+    auto set_combobox = [](QComboBox& box, const std::string& str)
+    {
+        box.setCurrentText(QString::fromStdString(str));
+    };
+
+    ConfigurationMode mode{};
+    controller_settings_->get_config_mode(mode);
+    set_combobox(*ui->mode_box, IControllerSettings::config_mode_to_string(mode));
+    if(mode != ConfigurationMode::MANUAL)
+    {
+        ui->buttons_box->setHidden(true);
+        ui->analog_stick_box->setHidden(true);
+        ui->c_box->setHidden(true);
+        ui->d_pad_box->setHidden(true);
+    }
+
+
+    ControllerPak pak{ControllerPak::NONE};
+    controller_settings_->get_pak(pak);
+    set_combobox(*ui->pak_box, IControllerSettings::pak_to_string(pak));
+
+
+    // Load button mappings
+    for(auto& btn : sdl_bind_buttons_)
+    {
+        btn->set_settings_handle(controller_settings_.get());
+        btn->load();
+    }
+
+    scan_devices();
+}
+
+void EmulatorControllerConfiguration::setup_sdl_buttons()
+{
+    sdl_bind_buttons_ = {
+        ui->a_button_btn,
+        ui->b_button_btn,
+        ui->z_trigger_btn,
+        ui->l_trigger_btn,
+        ui->r_trigger_btn,
+        ui->start_btn,
+        ui->d_pad_up_btn,
+        ui->d_pad_down_btn,
+        ui->d_pad_left_btn,
+        ui->d_pad_right_btn,
+        ui->c_up_btn,
+        ui->c_down_btn,
+        ui->c_left_btn,
+        ui->c_right_btn,
+        ui->stick_up_btn,
+        ui->stick_down_btn,
+        ui->stick_left_btn,
+        ui->stick_right_btn
+    };
+
+    auto set = [this](N64Button btn)
+    {
+        sdl_bind_buttons_[static_cast<std::size_t>(btn)]->n64_button = btn;
+    };
+
+    for(std::size_t i{}; i < static_cast<std::size_t>(N64Button::NUM_BUTTONS); ++i)
+    {
+        set(static_cast<N64Button>(i));
+    }
+}
+
+}

--- a/src/qt_gui/emulator_controller_configuration.cpp
+++ b/src/qt_gui/emulator_controller_configuration.cpp
@@ -3,12 +3,10 @@
 
 namespace Frontend
 {
-
 using namespace Net64::Emulator;
 
 EmulatorControllerConfiguration::EmulatorControllerConfiguration(QWidget* parent):
-    QWidget(parent),
-    ui(new Ui::EmulatorControllerConfiguration)
+    QWidget(parent), ui(new Ui::EmulatorControllerConfiguration)
 {
     ui->setupUi(this);
 
@@ -20,25 +18,24 @@ EmulatorControllerConfiguration::EmulatorControllerConfiguration(QWidget* parent
     ui->mode_box->addItem(IControllerSettings::config_mode_to_string(ConfigurationMode::AUTO_NAMED_SDL_DEV));
     ui->mode_box->addItem(IControllerSettings::config_mode_to_string(ConfigurationMode::MANUAL));
 
-    connect(ui->mode_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
-    {
+    connect(ui->mode_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int) {
         if(!controller_settings_)
             return;
 
-        controller_settings_->set_config_mode(IControllerSettings::config_mode_from_string(ui->mode_box->currentText().toStdString()).value());
+        controller_settings_->set_config_mode(
+            IControllerSettings::config_mode_from_string(ui->mode_box->currentText().toStdString()).value());
         update_interface();
     });
 
-    connect(ui->pak_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
-    {
+    connect(ui->pak_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int) {
         if(!controller_settings_)
             return;
 
-        controller_settings_->set_pak(IControllerSettings::pak_from_string(ui->pak_box->currentText().toStdString()).value());
+        controller_settings_->set_pak(
+            IControllerSettings::pak_from_string(ui->pak_box->currentText().toStdString()).value());
     });
 
-    connect(ui->device_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int)
-    {
+    connect(ui->device_box, qOverload<int>(&QComboBox::currentIndexChanged), [this](int) {
         if(!controller_settings_ || ui->device_box->count() < 2)
             return;
 
@@ -72,7 +69,9 @@ EmulatorControllerConfiguration::EmulatorControllerConfiguration(QWidget* parent
             if(!joystick_)
             {
                 logger()->error("Failed to open joystick {}:{}: {}",
-                                ui->device_box->currentText().toStdString(), joy_idx, SDL_GetError());
+                                ui->device_box->currentText().toStdString(),
+                                joy_idx,
+                                SDL_GetError());
                 return;
             }
 
@@ -117,7 +116,7 @@ bool EmulatorControllerConfiguration::has_settings_handle() const
     return bool(controller_settings_);
 }
 
-void EmulatorControllerConfiguration::handle_sdl_event(const SDL_Event &event)
+void EmulatorControllerConfiguration::handle_sdl_event(const SDL_Event& event)
 {
     switch(event.type)
     {
@@ -131,10 +130,7 @@ void EmulatorControllerConfiguration::handle_sdl_event(const SDL_Event &event)
 
 void EmulatorControllerConfiguration::scan_devices()
 {
-    auto set_combobox = [](QComboBox& box, const std::string& str)
-    {
-        box.setCurrentText(QString::fromStdString(str));
-    };
+    auto set_combobox = [](QComboBox& box, const std::string& str) { box.setCurrentText(QString::fromStdString(str)); };
 
     if(!controller_settings_)
         return;
@@ -215,10 +211,7 @@ void EmulatorControllerConfiguration::load_settings()
     if(!controller_settings_)
         return;
 
-    auto set_combobox = [](QComboBox& box, const std::string& str)
-    {
-        box.setCurrentText(QString::fromStdString(str));
-    };
+    auto set_combobox = [](QComboBox& box, const std::string& str) { box.setCurrentText(QString::fromStdString(str)); };
 
     ConfigurationMode mode{};
     controller_settings_->get_config_mode(mode);
@@ -249,31 +242,26 @@ void EmulatorControllerConfiguration::load_settings()
 
 void EmulatorControllerConfiguration::setup_sdl_buttons()
 {
-    sdl_bind_buttons_ = {
-        ui->a_button_btn,
-        ui->b_button_btn,
-        ui->z_trigger_btn,
-        ui->l_trigger_btn,
-        ui->r_trigger_btn,
-        ui->start_btn,
-        ui->d_pad_up_btn,
-        ui->d_pad_down_btn,
-        ui->d_pad_left_btn,
-        ui->d_pad_right_btn,
-        ui->c_up_btn,
-        ui->c_down_btn,
-        ui->c_left_btn,
-        ui->c_right_btn,
-        ui->stick_up_btn,
-        ui->stick_down_btn,
-        ui->stick_left_btn,
-        ui->stick_right_btn
-    };
+    sdl_bind_buttons_ = {ui->a_button_btn,
+                         ui->b_button_btn,
+                         ui->z_trigger_btn,
+                         ui->l_trigger_btn,
+                         ui->r_trigger_btn,
+                         ui->start_btn,
+                         ui->d_pad_up_btn,
+                         ui->d_pad_down_btn,
+                         ui->d_pad_left_btn,
+                         ui->d_pad_right_btn,
+                         ui->c_up_btn,
+                         ui->c_down_btn,
+                         ui->c_left_btn,
+                         ui->c_right_btn,
+                         ui->stick_up_btn,
+                         ui->stick_down_btn,
+                         ui->stick_left_btn,
+                         ui->stick_right_btn};
 
-    auto set = [this](N64Button btn)
-    {
-        sdl_bind_buttons_[static_cast<std::size_t>(btn)]->n64_button = btn;
-    };
+    auto set = [this](N64Button btn) { sdl_bind_buttons_[static_cast<std::size_t>(btn)]->n64_button = btn; };
 
     for(std::size_t i{}; i < static_cast<std::size_t>(N64Button::NUM_BUTTONS); ++i)
     {
@@ -281,4 +269,4 @@ void EmulatorControllerConfiguration::setup_sdl_buttons()
     }
 }
 
-}
+} // namespace Frontend

--- a/src/qt_gui/emulator_controller_configuration.hpp
+++ b/src/qt_gui/emulator_controller_configuration.hpp
@@ -1,0 +1,52 @@
+﻿#pragma once
+
+#include <QWidget>
+#include "qt_gui/sdl_bind_button.hpp"
+#ifndef Q_MOC_RUN
+#include "common/deleter.hpp"
+#include "net64/emulator/emulator.hpp"
+#endif
+
+namespace Ui {
+class EmulatorControllerConfiguration;
+}
+
+namespace Frontend
+{
+
+struct EmulatorControllerConfiguration : QWidget, SDL_EventHandler
+{
+    Q_OBJECT
+
+public:
+    using N64Button = Net64::Emulator::IControllerSettings::N64Button;
+    using ConfigurationMode = Net64::Emulator::IControllerSettings::ConfigurationMode;
+    using ControllerPak = Net64::Emulator::IControllerSettings::ControllerPak;
+    using sdl_input_t = Net64::Emulator::IControllerSettings::sdl_input_t;
+
+    explicit EmulatorControllerConfiguration(QWidget* parent = nullptr);
+    ~EmulatorControllerConfiguration();
+
+public slots:
+    void set_settings_handle(Net64::Emulator::IControllerSettings* settings);
+
+    bool has_settings_handle() const;
+
+private:
+    void handle_sdl_event(const SDL_Event& event) override;
+
+    void scan_devices();
+
+    void update_interface();
+    void load_settings();
+    void setup_sdl_buttons();
+
+    Ui::EmulatorControllerConfiguration *ui;
+    std::unique_ptr<SDL_Joystick, Deleter<&SDL_JoystickClose>> joystick_;
+    std::vector<SDL_BindButton*> sdl_bind_buttons_;
+    std::unique_ptr<Net64::Emulator::IControllerSettings> controller_settings_;
+
+    CLASS_LOGGER_("frontend")
+};
+
+}

--- a/src/qt_gui/emulator_controller_configuration.hpp
+++ b/src/qt_gui/emulator_controller_configuration.hpp
@@ -1,19 +1,18 @@
 ﻿#pragma once
 
 #include <QWidget>
-#include "qt_gui/sdl_bind_button.hpp"
-#ifndef Q_MOC_RUN
+
 #include "common/deleter.hpp"
 #include "net64/emulator/emulator.hpp"
-#endif
+#include "qt_gui/sdl_bind_button.hpp"
 
-namespace Ui {
+namespace Ui
+{
 class EmulatorControllerConfiguration;
 }
 
 namespace Frontend
 {
-
 struct EmulatorControllerConfiguration : QWidget, SDL_EventHandler
 {
     Q_OBJECT
@@ -41,7 +40,7 @@ private:
     void load_settings();
     void setup_sdl_buttons();
 
-    Ui::EmulatorControllerConfiguration *ui;
+    Ui::EmulatorControllerConfiguration* ui;
     std::unique_ptr<SDL_Joystick, Deleter<&SDL_JoystickClose>> joystick_;
     std::vector<SDL_BindButton*> sdl_bind_buttons_;
     std::unique_ptr<Net64::Emulator::IControllerSettings> controller_settings_;
@@ -49,4 +48,4 @@ private:
     CLASS_LOGGER_("frontend")
 };
 
-}
+} // namespace Frontend

--- a/src/qt_gui/emulator_controller_configuration.ui
+++ b/src/qt_gui/emulator_controller_configuration.ui
@@ -1,0 +1,645 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EmulatorControllerConfiguration</class>
+ <widget class="QWidget" name="EmulatorControllerConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>573</width>
+    <height>539</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="settings_box">
+     <property name="title">
+      <string>Device</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_5">
+      <item row="0" column="0">
+       <widget class="QLabel" name="device_lbl">
+        <property name="text">
+         <string>Device</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="device_box"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mode_lbl">
+        <property name="text">
+         <string>Configuration mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="mode_box"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="pak_lbl">
+        <property name="text">
+         <string>Expansion pak</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="pak_box"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="2" rowspan="2">
+        <widget class="QGroupBox" name="c_box">
+         <property name="title">
+          <string>C-Buttons</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="c_up_lbl">
+            <property name="text">
+             <string>Up</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Frontend::SDL_BindButton" name="c_up_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="c_down_lbl">
+            <property name="text">
+             <string>Down</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Frontend::SDL_BindButton" name="c_down_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="c_left_lbl">
+            <property name="text">
+             <string>Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Frontend::SDL_BindButton" name="c_left_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="c_right_lbl">
+            <property name="text">
+             <string>Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Frontend::SDL_BindButton" name="c_right_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="d_pad_box">
+         <property name="title">
+          <string>D-Pad</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="d_pad_up_lbl">
+            <property name="text">
+             <string>Up</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Frontend::SDL_BindButton" name="d_pad_up_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="d_pad_down_lbl">
+            <property name="text">
+             <string>Down</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Frontend::SDL_BindButton" name="d_pad_down_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="d_pad_left_lbl">
+            <property name="text">
+             <string>Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Frontend::SDL_BindButton" name="d_pad_left_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="d_pad_right_lbl">
+            <property name="text">
+             <string>Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Frontend::SDL_BindButton" name="d_pad_right_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0" rowspan="2">
+        <widget class="QGroupBox" name="analog_stick_box">
+         <property name="title">
+          <string>Analog Stick</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="stick_up_lbl">
+            <property name="text">
+             <string>Up</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Frontend::SDL_BindButton" name="stick_up_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="stick_down_lbl">
+            <property name="text">
+             <string>Down</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Frontend::SDL_BindButton" name="stick_down_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="stick_left_lbl">
+            <property name="text">
+             <string>Left</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Frontend::SDL_BindButton" name="stick_left_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="stick_right_lbl">
+            <property name="text">
+             <string>Right</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Frontend::SDL_BindButton" name="stick_right_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="deadzone_lbl">
+            <property name="text">
+             <string>Deadzone</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QSpinBox" name="deadzone_sbx">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="maximum">
+             <number>50</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="peak_lbl">
+            <property name="text">
+             <string>Peak</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="peak_sbx">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>51</number>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QGroupBox" name="buttons_box">
+         <property name="title">
+          <string>Buttons</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="0">
+           <widget class="QLabel" name="a_button_lbl">
+            <property name="text">
+             <string>A</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Frontend::SDL_BindButton" name="a_button_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="b_button_lbl">
+            <property name="text">
+             <string>B</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Frontend::SDL_BindButton" name="b_button_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="start_lbl">
+            <property name="text">
+             <string>Start</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Frontend::SDL_BindButton" name="start_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="z_trigger_lbl">
+            <property name="text">
+             <string>Z-Trigger</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Frontend::SDL_BindButton" name="z_trigger_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="l_trigger_lbl">
+            <property name="text">
+             <string>L-Trigger</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="Frontend::SDL_BindButton" name="l_trigger_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="r_trigger_lbl">
+            <property name="text">
+             <string>R-Trigger</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="Frontend::SDL_BindButton" name="r_trigger_btn">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Frontend::SDL_BindButton</class>
+   <extends>QPushButton</extends>
+   <header>sdl_bind_button.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt_gui/emulator_video_configuration.cpp
+++ b/src/qt_gui/emulator_video_configuration.cpp
@@ -1,0 +1,110 @@
+#include "emulator_video_configuration.hpp"
+#include "ui_emulator_video_configuration.h"
+
+#include <QCheckBox>
+#include <QSpinBox>
+
+
+namespace Frontend
+{
+
+EmulatorVideoConfiguration::EmulatorVideoConfiguration(QWidget* parent):
+    QWidget(parent),
+    ui(new Ui::EmulatorVideoConfiguration)
+{
+    ui->setupUi(this);
+
+    connect(ui->vsync_cbx, &QCheckBox::stateChanged, [this](int state)
+    {
+        if(!video_settings_)
+            return;
+
+        video_settings_->set_vsync(static_cast<bool>(state));
+    });
+
+    connect(ui->fullscreen_cbx, &QCheckBox::stateChanged, [this](int state)
+    {
+        if(!video_settings_)
+            return;
+
+        video_settings_->set_fullscreen(static_cast<bool>(state));
+    });
+
+    connect(ui->width_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value)
+    {
+        if(!video_settings_)
+            return;
+
+        video_settings_->set_dimensions(static_cast<unsigned>(value), static_cast<unsigned>(ui->height_sbx->value()));
+    });
+
+    connect(ui->height_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value)
+    {
+        if(!video_settings_)
+            return;
+
+        video_settings_->set_dimensions(static_cast<unsigned>(ui->width_sbx->value()), static_cast<unsigned>(value));
+    });
+
+    update_interface();
+}
+
+EmulatorVideoConfiguration::~EmulatorVideoConfiguration()
+{
+    delete ui;
+}
+
+void EmulatorVideoConfiguration::set_settings_handle(Net64::Emulator::IVideoSettings* settings)
+{
+    video_settings_.reset(settings);
+
+    update_interface();
+}
+
+bool EmulatorVideoConfiguration::has_settings_handle() const
+{
+    return (bool)video_settings_;
+}
+
+void EmulatorVideoConfiguration::update_interface()
+{
+    if(!video_settings_)
+    {
+        ui->fullscreen_cbx->setHidden(true);
+        ui->vsync_cbx->setHidden(true);
+        ui->resolution_box->setHidden(true);
+        return;
+    }
+
+    bool tmp{};
+    unsigned w{}, h{};
+    ui->fullscreen_cbx->setHidden(!video_settings_->get_fullscreen(tmp));
+    ui->fullscreen_cbx->setDisabled(!video_settings_->set_fullscreen(tmp));
+
+    ui->vsync_cbx->setHidden(!video_settings_->get_vsync(tmp));
+    ui->vsync_cbx->setDisabled(!video_settings_->set_vsync(tmp));
+
+    ui->resolution_box->setHidden(!video_settings_->get_dimensions(w, h));
+    ui->resolution_box->setDisabled(!video_settings_->set_dimensions(w, h));
+
+    load_settings();
+}
+
+void EmulatorVideoConfiguration::load_settings()
+{
+    if(!video_settings_)
+        return;
+
+    bool vsync{}, fullscreen{};
+    unsigned width{}, height{};
+    video_settings_->get_vsync(vsync);
+    video_settings_->get_fullscreen(fullscreen);
+    video_settings_->get_dimensions(width, height);
+
+    ui->vsync_cbx->setChecked(vsync);
+    ui->fullscreen_cbx->setChecked(fullscreen);
+    ui->height_sbx->setValue((int)height);
+    ui->width_sbx->setValue((int)width);
+}
+
+} // Frontend

--- a/src/qt_gui/emulator_video_configuration.cpp
+++ b/src/qt_gui/emulator_video_configuration.cpp
@@ -1,45 +1,39 @@
-#include "emulator_video_configuration.hpp"
-#include "ui_emulator_video_configuration.h"
-
 #include <QCheckBox>
 #include <QSpinBox>
+
+#include "emulator_video_configuration.hpp"
+#include "ui_emulator_video_configuration.h"
 
 
 namespace Frontend
 {
-
 EmulatorVideoConfiguration::EmulatorVideoConfiguration(QWidget* parent):
-    QWidget(parent),
-    ui(new Ui::EmulatorVideoConfiguration)
+    QWidget(parent), ui(new Ui::EmulatorVideoConfiguration)
 {
     ui->setupUi(this);
 
-    connect(ui->vsync_cbx, &QCheckBox::stateChanged, [this](int state)
-    {
+    connect(ui->vsync_cbx, &QCheckBox::stateChanged, [this](int state) {
         if(!video_settings_)
             return;
 
         video_settings_->set_vsync(static_cast<bool>(state));
     });
 
-    connect(ui->fullscreen_cbx, &QCheckBox::stateChanged, [this](int state)
-    {
+    connect(ui->fullscreen_cbx, &QCheckBox::stateChanged, [this](int state) {
         if(!video_settings_)
             return;
 
         video_settings_->set_fullscreen(static_cast<bool>(state));
     });
 
-    connect(ui->width_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value)
-    {
+    connect(ui->width_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value) {
         if(!video_settings_)
             return;
 
         video_settings_->set_dimensions(static_cast<unsigned>(value), static_cast<unsigned>(ui->height_sbx->value()));
     });
 
-    connect(ui->height_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value)
-    {
+    connect(ui->height_sbx, qOverload<int>(&QSpinBox::valueChanged), [this](int value) {
         if(!video_settings_)
             return;
 
@@ -107,4 +101,4 @@ void EmulatorVideoConfiguration::load_settings()
     ui->width_sbx->setValue((int)width);
 }
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/emulator_video_configuration.hpp
+++ b/src/qt_gui/emulator_video_configuration.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QWidget>
+#ifndef Q_MOC_RUN
+#include "net64/emulator/emulator.hpp"
+#endif
+
+namespace Ui {
+class EmulatorVideoConfiguration;
+}
+
+namespace Frontend
+{
+
+struct EmulatorVideoConfiguration : QWidget
+{
+Q_OBJECT
+
+public:
+    explicit EmulatorVideoConfiguration(QWidget* parent = nullptr);
+    ~EmulatorVideoConfiguration();
+
+public slots:
+    void set_settings_handle(Net64::Emulator::IVideoSettings* settings);
+
+    bool has_settings_handle() const;
+
+private:
+    void update_interface();
+    void load_settings();
+
+    Ui::EmulatorVideoConfiguration* ui;
+    std::unique_ptr<Net64::Emulator::IVideoSettings> video_settings_;
+};
+
+} // Frontend

--- a/src/qt_gui/emulator_video_configuration.hpp
+++ b/src/qt_gui/emulator_video_configuration.hpp
@@ -1,20 +1,19 @@
 #pragma once
 
 #include <QWidget>
-#ifndef Q_MOC_RUN
-#include "net64/emulator/emulator.hpp"
-#endif
 
-namespace Ui {
+#include "net64/emulator/emulator.hpp"
+
+namespace Ui
+{
 class EmulatorVideoConfiguration;
 }
 
 namespace Frontend
 {
-
 struct EmulatorVideoConfiguration : QWidget
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
     explicit EmulatorVideoConfiguration(QWidget* parent = nullptr);
@@ -33,4 +32,4 @@ private:
     std::unique_ptr<Net64::Emulator::IVideoSettings> video_settings_;
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/emulator_video_configuration.ui
+++ b/src/qt_gui/emulator_video_configuration.ui
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EmulatorVideoConfiguration</class>
+ <widget class="QWidget" name="EmulatorVideoConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Display</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="fullscreen_cbx">
+        <property name="text">
+         <string>Fullscreen</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="vsync_cbx">
+        <property name="text">
+         <string>VSync</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="resolution_box">
+        <property name="title">
+         <string>Dimensions</string>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="width_lbl">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Width</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="width_sbx">
+           <property name="minimum">
+            <number>640</number>
+           </property>
+           <property name="maximum">
+            <number>65000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="height_sbx">
+           <property name="minimum">
+            <number>480</number>
+           </property>
+           <property name="maximum">
+            <number>65000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="height_lbl">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Height</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt_gui/emulatorsettings.cpp
+++ b/src/qt_gui/emulatorsettings.cpp
@@ -3,11 +3,8 @@
 
 namespace Frontend
 {
-
 EmulatorSettings::EmulatorSettings(AppSettings& settings, QWidget* parent):
-    QDialog(parent),
-    ui(new Ui::EmulatorSettings),
-    config_{&settings}
+    QDialog(parent), ui(new Ui::EmulatorSettings), config_{&settings}
 {
     ui->setupUi(this);
     setFixedSize(sizeHint());
@@ -16,10 +13,7 @@ EmulatorSettings::EmulatorSettings(AppSettings& settings, QWidget* parent):
 
     connect(m64p_config_win_, &M64PSettings::core_lib_changed, this, &EmulatorSettings::on_core_lib_changed);
 
-    connect(ui->config_emu_btn, &QPushButton::pressed, [this]()
-    {
-        show_window(m64p_config_win_, *config_);
-    });
+    connect(ui->config_emu_btn, &QPushButton::pressed, [this]() { show_window(m64p_config_win_, *config_); });
 
     update_interface();
 }
@@ -65,4 +59,4 @@ void EmulatorSettings::on_core_lib_changed()
     reload_emulator();
 }
 
-}
+} // namespace Frontend

--- a/src/qt_gui/emulatorsettings.cpp
+++ b/src/qt_gui/emulatorsettings.cpp
@@ -1,0 +1,68 @@
+#include "emulatorsettings.hpp"
+#include "ui_emulatorsettings.h"
+
+namespace Frontend
+{
+
+EmulatorSettings::EmulatorSettings(AppSettings& settings, QWidget* parent):
+    QDialog(parent),
+    ui(new Ui::EmulatorSettings),
+    config_{&settings}
+{
+    ui->setupUi(this);
+    setFixedSize(sizeHint());
+
+    m64p_config_win_ = new M64PSettings(*config_, this);
+
+    connect(m64p_config_win_, &M64PSettings::core_lib_changed, this, &EmulatorSettings::on_core_lib_changed);
+
+    connect(ui->config_emu_btn, &QPushButton::pressed, [this]()
+    {
+        show_window(m64p_config_win_, *config_);
+    });
+
+    update_interface();
+}
+
+EmulatorSettings::~EmulatorSettings()
+{
+    delete ui;
+}
+
+void EmulatorSettings::set_emulator_object(Net64::Emulator::IEmulator* emu)
+{
+    emulator_ = emu;
+    update_interface();
+}
+
+void EmulatorSettings::update_interface()
+{
+    if(!emulator_)
+    {
+        ui->tabWidget->setTabEnabled(Tab::AUDIO, false);
+        ui->tabWidget->setTabEnabled(Tab::CONTROLLER, false);
+        ui->tabWidget->setTabEnabled(Tab::VIDEO, false);
+        return;
+    }
+
+    ui->audio_widget->set_settings_handle(emulator_->audio_settings().release());
+    ui->tabWidget->setTabEnabled(Tab::AUDIO, ui->audio_widget->has_settings_handle());
+    ui->video_widget->set_settings_handle(emulator_->video_settings().release());
+    ui->tabWidget->setTabEnabled(Tab::VIDEO, ui->video_widget->has_settings_handle());
+    ui->controller_widget->set_settings_handle(emulator_->controller_settings(0).release());
+    ui->tabWidget->setTabEnabled(Tab::CONTROLLER, ui->controller_widget->has_settings_handle());
+}
+
+void EmulatorSettings::showEvent(QShowEvent* event)
+{
+    QDialog::showEvent(event);
+
+    update_interface();
+}
+
+void EmulatorSettings::on_core_lib_changed()
+{
+    reload_emulator();
+}
+
+}

--- a/src/qt_gui/emulatorsettings.hpp
+++ b/src/qt_gui/emulatorsettings.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <QDialog>
+#ifndef Q_MOC_RUN
+#include "net64/emulator/emulator.hpp"
+#endif
+#include "qt_gui/app_settings.hpp"
+#include "qt_gui/m64p_settings_window.hpp"
+
+
+namespace Ui {
+class EmulatorSettings;
+}
+
+namespace Frontend
+{
+
+struct EmulatorSettings : QDialog
+{
+Q_OBJECT
+
+public:
+
+    struct Tab
+    {
+        enum
+        {
+            EMULATOR,
+            CONTROLLER,
+            VIDEO,
+            AUDIO
+        };
+    };
+
+    explicit EmulatorSettings(AppSettings& settings, QWidget* parent = nullptr);
+    ~EmulatorSettings();
+
+signals:
+    void reload_emulator();
+
+public slots:
+    void on_core_lib_changed();
+    void set_emulator_object(Net64::Emulator::IEmulator* emu);
+    void update_interface();
+
+protected:
+    void showEvent(QShowEvent* event) override;
+
+private:
+    template<typename T, typename... TArgs>
+    void show_window(T*& win_ptr, TArgs&&... args)
+    {
+        if(!win_ptr)
+        {
+            win_ptr = new T(std::forward<TArgs>(args)..., this);
+        }
+
+        win_ptr->show();
+        win_ptr->raise();
+        win_ptr->activateWindow();
+    }
+
+    Ui::EmulatorSettings* ui;
+    AppSettings* config_;
+    M64PSettings* m64p_config_win_{};
+    Net64::Emulator::IEmulator* emulator_{};
+};
+
+} // Frontend

--- a/src/qt_gui/emulatorsettings.hpp
+++ b/src/qt_gui/emulatorsettings.hpp
@@ -1,26 +1,24 @@
 #pragma once
 
 #include <QDialog>
-#ifndef Q_MOC_RUN
+
 #include "net64/emulator/emulator.hpp"
-#endif
 #include "qt_gui/app_settings.hpp"
 #include "qt_gui/m64p_settings_window.hpp"
 
 
-namespace Ui {
+namespace Ui
+{
 class EmulatorSettings;
 }
 
 namespace Frontend
 {
-
 struct EmulatorSettings : QDialog
 {
-Q_OBJECT
+    Q_OBJECT
 
 public:
-
     struct Tab
     {
         enum
@@ -66,4 +64,4 @@ private:
     Net64::Emulator::IEmulator* emulator_{};
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/emulatorsettings.ui
+++ b/src/qt_gui/emulatorsettings.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EmulatorSettings</class>
+ <widget class="QDialog" name="EmulatorSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Emulator Configuration</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="emulator_tab">
+      <attribute name="title">
+       <string>Emulator</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QComboBox" name="comboBox">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>false</bool>
+           </property>
+           <item>
+            <property name="text">
+             <string>Mupen64Plus</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="config_emu_btn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Configure</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="controller_tab">
+      <attribute name="title">
+       <string>Controller</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <widget class="Frontend::EmulatorControllerConfiguration" name="controller_widget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="video_tab">
+      <attribute name="title">
+       <string>Video</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="Frontend::EmulatorVideoConfiguration" name="video_widget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="audio_tab">
+      <attribute name="title">
+       <string>Audio</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="Frontend::EmulatorAudioConfiguration" name="audio_widget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Frontend::EmulatorAudioConfiguration</class>
+   <extends>QWidget</extends>
+   <header>emulator_audio_configuration.hpp</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Frontend::EmulatorVideoConfiguration</class>
+   <extends>QWidget</extends>
+   <header>emulator_video_configuration.hpp</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Frontend::EmulatorControllerConfiguration</class>
+   <extends>QWidget</extends>
+   <header>emulator_controller_configuration.hpp</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -61,6 +61,12 @@ void M64PSettings::closeEvent(QCloseEvent*)
         to = from.currentText().toStdString();
     };
 
+    if(ui->core_plugin_box->currentText().toStdString() != settings_->m64p_core_plugin)
+    {
+        // Core lib changed
+        core_lib_changed();
+    }
+
     save(settings_->m64p_core_plugin, *ui->core_plugin_box);
     save(settings_->m64p_video_plugin, *ui->video_plugin_box);
     save(settings_->m64p_audio_plugin, *ui->audio_plugin_box);
@@ -72,8 +78,6 @@ void M64PSettings::closeEvent(QCloseEvent*)
 
 void M64PSettings::refresh_plugins()
 {
-    using namespace Net64::Emulator::M64PTypes;
-
     ui->audio_plugin_box->clear();
     ui->core_plugin_box->clear();
     ui->video_plugin_box->clear();

--- a/src/qt_gui/m64p_settings_window.cpp
+++ b/src/qt_gui/m64p_settings_window.cpp
@@ -1,16 +1,16 @@
 ﻿#include "m64p_settings_window.hpp"
-#include "ui_m64p_settings_window.h"
-#include "filesystem.hpp"
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QUrl>
 
+#include "filesystem.hpp"
+#include "ui_m64p_settings_window.h"
+
 
 namespace Frontend
 {
-
-M64PSettings::M64PSettings(AppSettings& settings, QWidget* parent)
-:QMainWindow(parent), ui(new Ui::M64PSettings), settings_{&settings}
+M64PSettings::M64PSettings(AppSettings& settings, QWidget* parent):
+    QMainWindow(parent), ui(new Ui::M64PSettings), settings_{&settings}
 {
     ui->setupUi(this);
     adjustSize();
@@ -36,9 +36,8 @@ void M64PSettings::on_open_plugin_folder()
 
 void M64PSettings::on_set_plugin_folder()
 {
-    auto dir{QFileDialog::getExistingDirectory(this, "Mupen64Plus Directory",
-        ui->folder_path_field->text(), QFileDialog::ShowDirsOnly)
-    };
+    auto dir{QFileDialog::getExistingDirectory(
+        this, "Mupen64Plus Directory", ui->folder_path_field->text(), QFileDialog::ShowDirsOnly)};
 
     if(!dir.isEmpty())
     {
@@ -56,10 +55,7 @@ void M64PSettings::on_reset_plugin_folder()
 
 void M64PSettings::closeEvent(QCloseEvent*)
 {
-    auto save = [](auto& to, const QComboBox& from)
-    {
-        to = from.currentText().toStdString();
-    };
+    auto save = [](auto& to, const QComboBox& from) { to = from.currentText().toStdString(); };
 
     if(ui->core_plugin_box->currentText().toStdString() != settings_->m64p_core_plugin)
     {
@@ -93,7 +89,7 @@ void M64PSettings::refresh_plugins()
             {
             case M64PLUGIN_CORE:
                 ui->core_plugin_box->addItem(file);
-            break;
+                break;
             case M64PLUGIN_RSP:
                 ui->rsp_plugin_box->addItem(file);
                 break;
@@ -105,7 +101,8 @@ void M64PSettings::refresh_plugins()
                 break;
             case M64PLUGIN_INPUT:
                 ui->input_plugin_box->addItem(file);
-            default: break;
+            default:
+                break;
             }
         }
     }
@@ -114,8 +111,7 @@ void M64PSettings::refresh_plugins()
         logger()->warn("Failed to inspect plugin folder {}: {}", ui->folder_path_field->text().toStdString(), e.what());
     }
 
-    auto set_index_if_found = [](QComboBox& widget, const std::string& text)
-    {
+    auto set_index_if_found = [](QComboBox& widget, const std::string& text) {
         int index{-1};
         if((index = widget.findText(QString::fromStdString(text))) != -1)
             widget.setCurrentIndex(index);
@@ -128,4 +124,4 @@ void M64PSettings::refresh_plugins()
     set_index_if_found(*ui->rsp_plugin_box, settings_->m64p_rsp_plugin);
 }
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/m64p_settings_window.hpp
+++ b/src/qt_gui/m64p_settings_window.hpp
@@ -1,19 +1,18 @@
 ﻿#pragma once
 
 #include <QMainWindow>
-#ifndef Q_MOC_RUN
+
 #include "net64/net64.hpp"
 #include "qt_gui/app_settings.hpp"
-#endif
 
 
-namespace Ui {
+namespace Ui
+{
 class M64PSettings;
 }
 
 namespace Frontend
 {
-
 struct M64PSettings : QMainWindow
 {
     Q_OBJECT
@@ -41,4 +40,4 @@ private:
     CLASS_LOGGER_("frontend")
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/m64p_settings_window.hpp
+++ b/src/qt_gui/m64p_settings_window.hpp
@@ -14,13 +14,16 @@ class M64PSettings;
 namespace Frontend
 {
 
-class M64PSettings : public QMainWindow
+struct M64PSettings : QMainWindow
 {
     Q_OBJECT
 
 public:
     M64PSettings(AppSettings& settings, QWidget* parent = nullptr);
     ~M64PSettings() override;
+
+signals:
+    void core_lib_changed();
 
 private slots:
     void on_close_pressed();

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -10,6 +10,7 @@
 #include <QApplication>
 #include <QStandardPaths>
 #include <QDir>
+#include <SDL.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include "build_info.hpp"
@@ -25,7 +26,6 @@ using Net64::LoggerPtr;
 
 static void set_default_mupen_plugins(AppSettings& settings)
 {
-    using namespace Net64::Emulator::M64PTypes;
     using Net64::Emulator::M64PlusHelper::Plugin;
 
     // Helper function
@@ -110,6 +110,7 @@ static void setup_logging()
 
 } // Frontend
 
+
 int main(int argc, char* argv[])
 {
     using namespace Frontend;
@@ -133,6 +134,12 @@ int main(int argc, char* argv[])
     if(!Net64::initialize())
     {
         logger->critical("Failed to Net64 library");
+        return EXIT_FAILURE;
+    }
+
+    if(SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_EVENTS) != 0)
+    {
+        logger->critical("Failed to initialize SDL: {}", SDL_GetError());
         return EXIT_FAILURE;
     }
 
@@ -162,6 +169,8 @@ int main(int argc, char* argv[])
     settings.save(settings.main_config_file_path());
 
     Net64::deinitialize();
+
+    SDL_Quit();
 
     return ret;
 }

--- a/src/qt_gui/main.cpp
+++ b/src/qt_gui/main.cpp
@@ -5,15 +5,17 @@
 // Refer to the LICENSE file included.
 //
 
-#include "filesystem.hpp"
 #include <iostream>
+
 #include <QApplication>
-#include <QStandardPaths>
 #include <QDir>
+#include <QStandardPaths>
 #include <SDL.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+
 #include "build_info.hpp"
+#include "filesystem.hpp"
 #include "net64/net64.hpp"
 #include "qt_gui/app_settings.hpp"
 #include "qt_gui/main_window.hpp"
@@ -21,7 +23,6 @@
 
 namespace Frontend
 {
-
 using Net64::LoggerPtr;
 
 static void set_default_mupen_plugins(AppSettings& settings)
@@ -29,8 +30,7 @@ static void set_default_mupen_plugins(AppSettings& settings)
     using Net64::Emulator::M64PlusHelper::Plugin;
 
     // Helper function
-    auto set_plugin_if_empty{[](auto& config_string, const auto& file_path, auto plugin_type)
-    {
+    auto set_plugin_if_empty{[](auto& config_string, const auto& file_path, auto plugin_type) {
         if(config_string.empty())
         {
             if(file_path.string().find(AppSettings::M64P_DEFAULT_PLUGINS[plugin_type]) != std::string::npos &&
@@ -40,8 +40,7 @@ static void set_default_mupen_plugins(AppSettings& settings)
             }
             else
             {
-                Net64::get_logger("frontend")->warn("Did not find default {} plugin",
-                                  Plugin::type_str(M64PLUGIN_CORE));
+                Net64::get_logger("frontend")->warn("Did not find default {} plugin", Plugin::type_str(M64PLUGIN_CORE));
             }
         }
     }};
@@ -64,7 +63,8 @@ static void install_routine(AppSettings& settings)
         try
         {
             fs::create_directories(settings.m64p_default_plugin_dir());
-            fs::copy(settings.shipped_m64p_binaries_dir(), settings.m64p_default_plugin_dir(), fs::copy_options::recursive);
+            fs::copy(
+                settings.shipped_m64p_binaries_dir(), settings.m64p_default_plugin_dir(), fs::copy_options::recursive);
             std::cout << "Mupen64Plus bin dir missing. Copied default binaries\n";
         }
         catch(const std::exception& e)
@@ -86,11 +86,8 @@ static void install_routine(AppSettings& settings)
 
 static void setup_logging()
 {
-    auto global_log_file{
-        std::make_shared<spdlog::sinks::basic_file_sink_mt>(
-            QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).toStdString() +
-            "/log.txt", true)
-    };
+    auto global_log_file{std::make_shared<spdlog::sinks::basic_file_sink_mt>(
+        QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).toStdString() + "/log.txt", true)};
     global_log_file->set_level(spdlog::level::debug);
 
     // Terminal logging
@@ -99,16 +96,14 @@ static void setup_logging()
     stdout_sink->set_level(spdlog::level::info);
 
     // Pass logging configuration to core
-    Net64::init_logging_sinks([global_log_file, stdout_sink]{
-        std::vector<spdlog::sink_ptr> sinks{
-            stdout_sink, global_log_file
-        };
+    Net64::init_logging_sinks([global_log_file, stdout_sink] {
+        std::vector<spdlog::sink_ptr> sinks{stdout_sink, global_log_file};
 
         return sinks;
     });
 }
 
-} // Frontend
+} // namespace Frontend
 
 
 int main(int argc, char* argv[])
@@ -148,12 +143,14 @@ int main(int argc, char* argv[])
         QApplication app{argc, argv};
 
         // Log system information
-        logger->info("Starting {} {}", QCoreApplication::applicationName().toStdString(),
+        logger->info("Starting {} {}",
+                     QCoreApplication::applicationName().toStdString(),
                      QCoreApplication::applicationVersion().toStdString());
-        logger->info("Operating system: {} {}", QSysInfo::productType().toStdString(),
-                     QSysInfo::productVersion().toStdString());
+        logger->info(
+            "Operating system: {} {}", QSysInfo::productType().toStdString(), QSysInfo::productVersion().toStdString());
         logger->info("Kernel: {} {}", QSysInfo::kernelType().toStdString(), QSysInfo::kernelVersion().toStdString());
-        logger->info("CPU architecture: buildtime={} runtime={}", QSysInfo::buildCpuArchitecture().toStdString(),
+        logger->info("CPU architecture: buildtime={} runtime={}",
+                     QSysInfo::buildCpuArchitecture().toStdString(),
                      QSysInfo::currentCpuArchitecture().toStdString());
         logger->info("Byte order: {}", QSysInfo::ByteOrder == QSysInfo::LittleEndian ? "Little" : "Big");
         logger->info("Configuration folder: {}", settings.appdata_path);
@@ -174,5 +171,3 @@ int main(int argc, char* argv[])
 
     return ret;
 }
-
-

--- a/src/qt_gui/main_window.hpp
+++ b/src/qt_gui/main_window.hpp
@@ -3,33 +3,32 @@
 #include <future>
 #include <memory>
 #include <optional>
+
 #include <QLabel>
 #include <QMainWindow>
 #include <QThread>
 #include <QTimer>
-#ifndef Q_MOC_RUN
+
 #include "common/sdl_event_handler.hpp"
 #include "net64/net64.hpp"
 #include "qt_gui/app_settings.hpp"
 #include "qt_gui/emulatorsettings.hpp"
 #include "qt_gui/multiplayer_settings_window.hpp"
 #include "qt_gui/net64_thread.hpp"
-#endif
 
 
-namespace Ui {
+namespace Ui
+{
 class MainWindow;
 }
 
 namespace Frontend
 {
-
 struct MainWindow : QMainWindow
 {
     Q_OBJECT
 
 public:
-
     enum struct Page : int
     {
         SETUP,
@@ -96,8 +95,7 @@ private:
     void connect_once(Sender sender, Signal signal, Functor fn)
     {
         auto context_ptr{new QObject};
-        QObject::connect(sender, signal, context_ptr, [this, fn, context_ptr](auto&&... args) mutable
-        {
+        QObject::connect(sender, signal, context_ptr, [this, fn, context_ptr](auto&&... args) mutable {
             fn(std::forward<decltype(args)>(args)...);
             delete context_ptr;
         });
@@ -120,4 +118,4 @@ private:
     CLASS_LOGGER_("frontend")
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/main_window.hpp
+++ b/src/qt_gui/main_window.hpp
@@ -8,9 +8,10 @@
 #include <QThread>
 #include <QTimer>
 #ifndef Q_MOC_RUN
+#include "common/sdl_event_handler.hpp"
 #include "net64/net64.hpp"
 #include "qt_gui/app_settings.hpp"
-#include "qt_gui/m64p_settings_window.hpp"
+#include "qt_gui/emulatorsettings.hpp"
 #include "qt_gui/multiplayer_settings_window.hpp"
 #include "qt_gui/net64_thread.hpp"
 #endif
@@ -39,12 +40,18 @@ public:
     ~MainWindow() override;
 
 signals:
+    void emulator_object_changed(Net64::Emulator::IEmulator*);
     void emulator_started();
     void emulator_paused();
     void emulator_unpaused();
     void emulator_joinable();
 
+public slots:
+    void reload_emulator();
+
 private slots:
+    void on_handle_sdl_events();
+
     void on_emulator_settings();
 
     void on_start_server_btn_pressed();
@@ -64,8 +71,10 @@ private slots:
 
     void set_page(Page page);
 
+    bool create_emulator();
     void start_emulation();
     void stop_emulation();
+    void destroy_emulator();
 
     void connect_net64();
 
@@ -97,14 +106,16 @@ private:
     Ui::MainWindow* ui;
     QLabel* statustext_{};
     AppSettings* settings_;
-    M64PSettings* m64p_cfg_win_{};
+    EmulatorSettings* emu_settings_win_{};
     MultiplayerSettingsWindow* multiplayer_cfg_win_{};
     Page last_page_{Page::SETUP};
+    QTimer* sdl_event_timer_{};
 
     std::vector<std::byte> rom_image_;
-    std::unique_ptr<Net64::Emulator::IEmulator> emulator_;
+    std::unique_ptr<Net64::Emulator::Mupen64Plus> emulator_;
     std::atomic<Net64::Emulator::State> emu_state_{Net64::Emulator::State::STOPPED};
     Net64Thread net64_thread_;
+    bool reload_emulator_after_stop_{};
 
     CLASS_LOGGER_("frontend")
 };

--- a/src/qt_gui/net64_thread.cpp
+++ b/src/qt_gui/net64_thread.cpp
@@ -78,6 +78,7 @@ void Net64Obj::tick()
             try{client_ = Net64::Client(*memory_hdl_);}
             catch(const std::system_error& e)
             {
+                logger()->error("Error while starting Net64 client: {}", error_msg(e));
                 ec = e.code();
             }
             catch(const std::exception& e)

--- a/src/qt_gui/net64_thread.cpp
+++ b/src/qt_gui/net64_thread.cpp
@@ -20,9 +20,7 @@ static std::string error_msg(const std::system_error& e)
 
 namespace Frontend
 {
-
-Net64Obj::Net64Obj(AppSettings& config):
-    settings_{&config}
+Net64Obj::Net64Obj(AppSettings& config): settings_{&config}
 {
     timer_->setTimerType(Qt::PreciseTimer);
     timer_->setInterval(CLIENT_INTERV.count());
@@ -32,7 +30,6 @@ Net64Obj::Net64Obj(AppSettings& config):
 
 Net64Obj::~Net64Obj()
 {
-
 }
 
 void Net64Obj::set_config(AppSettings* config)
@@ -48,12 +45,10 @@ void Net64Obj::initialize_net64(Net64::Emulator::IEmulator* emu)
 
 void Net64Obj::connect(std::string ip, std::uint16_t port)
 {
-
 }
 
 void Net64Obj::disconnect()
 {
-
 }
 
 void Net64Obj::destroy_net64()
@@ -75,7 +70,10 @@ void Net64Obj::tick()
         if(Net64::Client::game_initialized(*memory_hdl_))
         {
             std::error_code ec;
-            try{client_ = Net64::Client(*memory_hdl_);}
+            try
+            {
+                client_ = Net64::Client(*memory_hdl_);
+            }
             catch(const std::system_error& e)
             {
                 logger()->error("Error while starting Net64 client: {}", error_msg(e));
@@ -202,4 +200,4 @@ void Net64Thread::o_net64_destroyed()
     net64_destroyed();
 }
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/net64_thread.hpp
+++ b/src/qt_gui/net64_thread.hpp
@@ -10,17 +10,16 @@
 #include <chrono>
 #include <functional>
 #include <future>
+
 #include <QThread>
 #include <QTimer>
-#ifndef Q_MOC_RUN
+
 #include "net64/net64.hpp"
 #include "qt_gui/app_settings.hpp"
-#endif
 
 
 namespace Frontend
 {
-
 struct Net64Obj : QObject
 {
     Q_OBJECT
@@ -103,7 +102,6 @@ private:
     bool is_initializing_{};
     bool is_initialized_{};
     bool is_connected_{};
-
 };
 
-} // Frontend
+} // namespace Frontend

--- a/src/qt_gui/sdl_bind_button.cpp
+++ b/src/qt_gui/sdl_bind_button.cpp
@@ -5,22 +5,21 @@
 // Refer to the LICENSE file included
 //
 
-#include "sdl_bind_button.hpp"
-
 #include <unordered_map>
+
+#include <QInputEvent>
 #include <SDL_joystick.h>
 #include <SDL_keycode.h>
 #include <SDL_mouse.h>
-#include <QInputEvent>
+
+#include "sdl_bind_button.hpp"
 
 
 namespace Frontend
 {
-
 extern const std::unordered_map<Qt::Key, SDL_Keycode> QT_SDL_KEYMAP;
 
-SDL_BindButton::SDL_BindButton(QWidget* parent):
-    QPushButton(parent)
+SDL_BindButton::SDL_BindButton(QWidget* parent): QPushButton(parent)
 {
 }
 
@@ -95,8 +94,14 @@ void SDL_BindButton::keyPressEvent(QKeyEvent* event)
     }
 
     input_.type = sdl_input_t::Type::KEY;
-    try{input_.key_code = QT_SDL_KEYMAP.at((Qt::Key)event->key());}
-    catch(const std::out_of_range&){return;}
+    try
+    {
+        input_.key_code = QT_SDL_KEYMAP.at((Qt::Key)event->key());
+    }
+    catch(const std::out_of_range&)
+    {
+        return;
+    }
 
     set_bind(input_);
 }
@@ -183,8 +188,7 @@ void SDL_BindButton::update_text()
         return;
     }
 
-    auto hat_dir{[](int val) -> std::string
-    {
+    auto hat_dir{[](int val) -> std::string {
         if(val & SDL_HAT_UP)
             return "UP";
         if(val & SDL_HAT_DOWN)
@@ -224,97 +228,95 @@ void SDL_BindButton::update_text()
     setText(QString::fromStdString(label));
 }
 
-const std::unordered_map<Qt::Key, SDL_Keycode> QT_SDL_KEYMAP{
-    {Qt::Key_A, SDLK_a},
-    {Qt::Key_B, SDLK_b},
-    {Qt::Key_C, SDLK_c},
-    {Qt::Key_D, SDLK_d},
-    {Qt::Key_E, SDLK_e},
-    {Qt::Key_F, SDLK_f},
-    {Qt::Key_G, SDLK_g},
-    {Qt::Key_H, SDLK_h},
-    {Qt::Key_I, SDLK_i},
-    {Qt::Key_J, SDLK_j},
-    {Qt::Key_K, SDLK_k},
-    {Qt::Key_L, SDLK_l},
-    {Qt::Key_M, SDLK_m},
-    {Qt::Key_N, SDLK_n},
-    {Qt::Key_O, SDLK_o},
-    {Qt::Key_P, SDLK_p},
-    {Qt::Key_Q, SDLK_q},
-    {Qt::Key_R, SDLK_r},
-    {Qt::Key_S, SDLK_s},
-    {Qt::Key_T, SDLK_t},
-    {Qt::Key_U, SDLK_u},
-    {Qt::Key_V, SDLK_v},
-    {Qt::Key_W, SDLK_w},
-    {Qt::Key_X, SDLK_x},
-    {Qt::Key_Y, SDLK_y},
-    {Qt::Key_Z, SDLK_z},
-    {Qt::Key_0, SDLK_0},
-    {Qt::Key_1, SDLK_1},
-    {Qt::Key_2, SDLK_2},
-    {Qt::Key_3, SDLK_3},
-    {Qt::Key_4, SDLK_4},
-    {Qt::Key_5, SDLK_5},
-    {Qt::Key_6, SDLK_6},
-    {Qt::Key_7, SDLK_7},
-    {Qt::Key_8, SDLK_8},
-    {Qt::Key_9, SDLK_9},
-    {Qt::Key_F1, SDLK_F1},
-    {Qt::Key_F2, SDLK_F2},
-    {Qt::Key_F3, SDLK_F3},
-    {Qt::Key_F4, SDLK_F4},
-    {Qt::Key_F5, SDLK_F5},
-    {Qt::Key_F6, SDLK_F6},
-    {Qt::Key_F7, SDLK_F7},
-    {Qt::Key_F8, SDLK_F8},
-    {Qt::Key_F9, SDLK_F9},
-    {Qt::Key_F10, SDLK_F10},
-    {Qt::Key_F11, SDLK_F11},
-    {Qt::Key_F12, SDLK_F12},
-    {Qt::Key_F13, SDLK_F13},
-    {Qt::Key_F14, SDLK_F14},
-    {Qt::Key_F15, SDLK_F15},
-    {Qt::Key_Insert, SDLK_INSERT},
-    {Qt::Key_Delete, SDLK_DELETE},
-    {Qt::Key_Home, SDLK_HOME},
-    {Qt::Key_End, SDLK_END},
-    {Qt::Key_PageUp, SDLK_PAGEUP},
-    {Qt::Key_PageDown, SDLK_PAGEDOWN},
-    {Qt::Key_Up, SDLK_UP},
-    {Qt::Key_Down, SDLK_DOWN},
-    {Qt::Key_Left, SDLK_LEFT},
-    {Qt::Key_Right, SDLK_RIGHT},
-    {Qt::Key_Return, SDLK_RETURN},
-    {Qt::Key_Enter, SDLK_RETURN2},
-    {Qt::Key_Escape, SDLK_ESCAPE},
-    {Qt::Key_Pause, SDLK_PAUSE},
-    {Qt::Key_QuoteLeft, SDLK_QUOTEDBL},
-    {Qt::Key_Backspace, SDLK_BACKSPACE},
-    {Qt::Key_Tab, SDLK_TAB},
-    {Qt::Key_CapsLock, SDLK_CAPSLOCK},
-    {Qt::Key_Space, SDLK_SPACE},
-    {Qt::Key_Slash, SDLK_SLASH},
-    {Qt::Key_Backslash, SDLK_BACKSLASH},
-    {Qt::Key_Minus, SDLK_MINUS},
-    {Qt::Key_Plus, SDLK_UNKNOWN},
-    {Qt::Key_Equal, SDLK_EQUALS},
-    {Qt::Key_BracketLeft, SDLK_LEFTBRACKET},
-    {Qt::Key_BracketRight, SDLK_RIGHTBRACKET},
-    {Qt::Key_Semicolon, SDLK_SEMICOLON},
-    {Qt::Key_Apostrophe, SDLK_QUOTE},
-    {Qt::Key_Comma, SDLK_COMMA},
-    {Qt::Key_Period, SDLK_PERIOD},
-    {Qt::Key_Alt, SDLK_LALT},
-    {Qt::Key_Control, SDLK_LCTRL},
-    {Qt::Key_Shift, SDLK_LSHIFT},
-    {Qt::Key_Print, SDLK_PRINTSCREEN},
-    {Qt::Key_ScrollLock, SDLK_SCROLLLOCK},
-    {Qt::Key_Meta, SDLK_LGUI},
-    {Qt::Key_Super_L, SDLK_LGUI},
-    {Qt::Key_Super_R, SDLK_RGUI},
-    {Qt::Key_unknown, SDLK_UNKNOWN}
-};
+const std::unordered_map<Qt::Key, SDL_Keycode> QT_SDL_KEYMAP{{Qt::Key_A, SDLK_a},
+                                                             {Qt::Key_B, SDLK_b},
+                                                             {Qt::Key_C, SDLK_c},
+                                                             {Qt::Key_D, SDLK_d},
+                                                             {Qt::Key_E, SDLK_e},
+                                                             {Qt::Key_F, SDLK_f},
+                                                             {Qt::Key_G, SDLK_g},
+                                                             {Qt::Key_H, SDLK_h},
+                                                             {Qt::Key_I, SDLK_i},
+                                                             {Qt::Key_J, SDLK_j},
+                                                             {Qt::Key_K, SDLK_k},
+                                                             {Qt::Key_L, SDLK_l},
+                                                             {Qt::Key_M, SDLK_m},
+                                                             {Qt::Key_N, SDLK_n},
+                                                             {Qt::Key_O, SDLK_o},
+                                                             {Qt::Key_P, SDLK_p},
+                                                             {Qt::Key_Q, SDLK_q},
+                                                             {Qt::Key_R, SDLK_r},
+                                                             {Qt::Key_S, SDLK_s},
+                                                             {Qt::Key_T, SDLK_t},
+                                                             {Qt::Key_U, SDLK_u},
+                                                             {Qt::Key_V, SDLK_v},
+                                                             {Qt::Key_W, SDLK_w},
+                                                             {Qt::Key_X, SDLK_x},
+                                                             {Qt::Key_Y, SDLK_y},
+                                                             {Qt::Key_Z, SDLK_z},
+                                                             {Qt::Key_0, SDLK_0},
+                                                             {Qt::Key_1, SDLK_1},
+                                                             {Qt::Key_2, SDLK_2},
+                                                             {Qt::Key_3, SDLK_3},
+                                                             {Qt::Key_4, SDLK_4},
+                                                             {Qt::Key_5, SDLK_5},
+                                                             {Qt::Key_6, SDLK_6},
+                                                             {Qt::Key_7, SDLK_7},
+                                                             {Qt::Key_8, SDLK_8},
+                                                             {Qt::Key_9, SDLK_9},
+                                                             {Qt::Key_F1, SDLK_F1},
+                                                             {Qt::Key_F2, SDLK_F2},
+                                                             {Qt::Key_F3, SDLK_F3},
+                                                             {Qt::Key_F4, SDLK_F4},
+                                                             {Qt::Key_F5, SDLK_F5},
+                                                             {Qt::Key_F6, SDLK_F6},
+                                                             {Qt::Key_F7, SDLK_F7},
+                                                             {Qt::Key_F8, SDLK_F8},
+                                                             {Qt::Key_F9, SDLK_F9},
+                                                             {Qt::Key_F10, SDLK_F10},
+                                                             {Qt::Key_F11, SDLK_F11},
+                                                             {Qt::Key_F12, SDLK_F12},
+                                                             {Qt::Key_F13, SDLK_F13},
+                                                             {Qt::Key_F14, SDLK_F14},
+                                                             {Qt::Key_F15, SDLK_F15},
+                                                             {Qt::Key_Insert, SDLK_INSERT},
+                                                             {Qt::Key_Delete, SDLK_DELETE},
+                                                             {Qt::Key_Home, SDLK_HOME},
+                                                             {Qt::Key_End, SDLK_END},
+                                                             {Qt::Key_PageUp, SDLK_PAGEUP},
+                                                             {Qt::Key_PageDown, SDLK_PAGEDOWN},
+                                                             {Qt::Key_Up, SDLK_UP},
+                                                             {Qt::Key_Down, SDLK_DOWN},
+                                                             {Qt::Key_Left, SDLK_LEFT},
+                                                             {Qt::Key_Right, SDLK_RIGHT},
+                                                             {Qt::Key_Return, SDLK_RETURN},
+                                                             {Qt::Key_Enter, SDLK_RETURN2},
+                                                             {Qt::Key_Escape, SDLK_ESCAPE},
+                                                             {Qt::Key_Pause, SDLK_PAUSE},
+                                                             {Qt::Key_QuoteLeft, SDLK_QUOTEDBL},
+                                                             {Qt::Key_Backspace, SDLK_BACKSPACE},
+                                                             {Qt::Key_Tab, SDLK_TAB},
+                                                             {Qt::Key_CapsLock, SDLK_CAPSLOCK},
+                                                             {Qt::Key_Space, SDLK_SPACE},
+                                                             {Qt::Key_Slash, SDLK_SLASH},
+                                                             {Qt::Key_Backslash, SDLK_BACKSLASH},
+                                                             {Qt::Key_Minus, SDLK_MINUS},
+                                                             {Qt::Key_Plus, SDLK_UNKNOWN},
+                                                             {Qt::Key_Equal, SDLK_EQUALS},
+                                                             {Qt::Key_BracketLeft, SDLK_LEFTBRACKET},
+                                                             {Qt::Key_BracketRight, SDLK_RIGHTBRACKET},
+                                                             {Qt::Key_Semicolon, SDLK_SEMICOLON},
+                                                             {Qt::Key_Apostrophe, SDLK_QUOTE},
+                                                             {Qt::Key_Comma, SDLK_COMMA},
+                                                             {Qt::Key_Period, SDLK_PERIOD},
+                                                             {Qt::Key_Alt, SDLK_LALT},
+                                                             {Qt::Key_Control, SDLK_LCTRL},
+                                                             {Qt::Key_Shift, SDLK_LSHIFT},
+                                                             {Qt::Key_Print, SDLK_PRINTSCREEN},
+                                                             {Qt::Key_ScrollLock, SDLK_SCROLLLOCK},
+                                                             {Qt::Key_Meta, SDLK_LGUI},
+                                                             {Qt::Key_Super_L, SDLK_LGUI},
+                                                             {Qt::Key_Super_R, SDLK_RGUI},
+                                                             {Qt::Key_unknown, SDLK_UNKNOWN}};
 
-}
+} // namespace Frontend

--- a/src/qt_gui/sdl_bind_button.cpp
+++ b/src/qt_gui/sdl_bind_button.cpp
@@ -1,0 +1,320 @@
+//
+// Created by henrik on 28.04.20.
+// Copyright 2020 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#include "sdl_bind_button.hpp"
+
+#include <unordered_map>
+#include <SDL_joystick.h>
+#include <SDL_keycode.h>
+#include <SDL_mouse.h>
+#include <QInputEvent>
+
+
+namespace Frontend
+{
+
+extern const std::unordered_map<Qt::Key, SDL_Keycode> QT_SDL_KEYMAP;
+
+SDL_BindButton::SDL_BindButton(QWidget* parent):
+    QPushButton(parent)
+{
+}
+
+void SDL_BindButton::set_joystick(SDL_JoystickID joy_id)
+{
+    joy_id_ = joy_id;
+}
+
+void SDL_BindButton::set_keyboard()
+{
+    joy_id_ = -1;
+}
+
+void SDL_BindButton::set_settings_handle(Net64::Emulator::IControllerSettings* handle)
+{
+    settings_handle_ = handle;
+}
+
+void SDL_BindButton::load()
+{
+    if(!settings_handle_)
+        return;
+
+    if(!settings_handle_->get_bind(n64_button, input_))
+        input_.type = sdl_input_t::Type::NONE;
+
+    set_bind(input_);
+}
+
+void SDL_BindButton::save()
+{
+    if(!settings_handle_)
+        return;
+
+    settings_handle_->set_bind(n64_button, input_);
+}
+
+void SDL_BindButton::set_bind(sdl_input_t input)
+{
+    input_ = input;
+
+    listening_ = false;
+
+    update_text();
+    save();
+}
+
+auto SDL_BindButton::get_bind() -> sdl_input_t
+{
+    return input_;
+}
+
+void SDL_BindButton::clear()
+{
+    input_.type = sdl_input_t::Type::NONE;
+    set_bind(input_);
+
+    update_text();
+}
+
+void SDL_BindButton::keyPressEvent(QKeyEvent* event)
+{
+    QPushButton::keyPressEvent(event);
+
+    if(!listening_)
+        return;
+
+    if(joy_id_ >= 0)
+    {
+        listening_ = false;
+        return;
+    }
+
+    input_.type = sdl_input_t::Type::KEY;
+    try{input_.key_code = QT_SDL_KEYMAP.at((Qt::Key)event->key());}
+    catch(const std::out_of_range&){return;}
+
+    set_bind(input_);
+}
+
+void SDL_BindButton::mouseReleaseEvent(QMouseEvent* event)
+{
+    QPushButton::mouseReleaseEvent(event);
+
+    if(!listening_)
+    {
+        if(event->button() == Qt::RightButton)
+            clear();
+        else if(event->button() == Qt::LeftButton)
+            listening_ = true;
+    }
+    else
+    {
+        if(joy_id_ >= 0 && event->button() == Qt::LeftButton)
+            listening_ = false;
+        else if(joy_id_ < 0)
+        {
+            input_.type = sdl_input_t::Type::MOUSE_BUTTON;
+            switch(event->button())
+            {
+            case Qt::LeftButton:
+                input_.mouse_button = SDL_BUTTON_LEFT;
+                break;
+            case Qt::RightButton:
+                input_.mouse_button = SDL_BUTTON_RIGHT;
+                break;
+            case Qt::MidButton:
+                input_.mouse_button = SDL_BUTTON_MIDDLE;
+                break;
+            }
+            set_bind(input_);
+        }
+    }
+
+    update_text();
+}
+
+void SDL_BindButton::handle_sdl_event(const SDL_Event& event)
+{
+    if(!listening_)
+        return;
+
+    switch(event.type)
+    {
+    case SDL_JOYBUTTONDOWN:
+        if(joy_id_ != event.jbutton.which)
+            return;
+        input_.type = sdl_input_t::Type::JOY_BUTTON;
+        input_.joy.index = event.jbutton.button;
+        set_bind(input_);
+        break;
+    case SDL_JOYHATMOTION:
+        if(joy_id_ != event.jhat.which)
+            return;
+        if(event.jhat.value == 0)
+            return;
+        input_.type = sdl_input_t::Type::JOY_HAT;
+        input_.joy.index = event.jhat.hat;
+        input_.joy.value = event.jhat.value;
+        set_bind(input_);
+        break;
+    case SDL_JOYAXISMOTION:
+        if(joy_id_ != event.jaxis.which)
+            return;
+        if(std::abs(event.jaxis.value) < 9830) // Register axis event only when moved 30%+
+            return;
+        input_.type = sdl_input_t::Type::JOY_AXIS;
+        input_.joy.index = event.jaxis.axis;
+        input_.joy.value = (event.jaxis.value > 0 ? 1 : -1);
+        set_bind(input_);
+        break;
+    }
+}
+
+void SDL_BindButton::update_text()
+{
+    if(listening_)
+    {
+        setText("...");
+        return;
+    }
+
+    auto hat_dir{[](int val) -> std::string
+    {
+        if(val & SDL_HAT_UP)
+            return "UP";
+        if(val & SDL_HAT_DOWN)
+            return "DOWN";
+        if(val & SDL_HAT_LEFT)
+            return "LEFT";
+        if(val & SDL_HAT_RIGHT)
+            return "RIGHT";
+        else
+            return "CENTERED";
+    }};
+
+    std::string label;
+
+    switch(input_.type)
+    {
+    case sdl_input_t::Type::NONE:
+        label = "";
+        break;
+    case sdl_input_t::Type::KEY:
+        label = "Key(" + std::string(SDL_GetKeyName(input_.key_code)) + ")";
+        break;
+    case sdl_input_t::Type::JOY_AXIS:
+        label = "Axis(" + std::to_string(input_.joy.index) + (input_.joy.value > 0 ? '+' : '-') + std::string(")");
+        break;
+    case sdl_input_t::Type::JOY_BUTTON:
+        label = "Button(" + std::to_string(input_.joy.index) + ")";
+        break;
+    case sdl_input_t::Type::JOY_HAT:
+        label = "Hat(" + std::to_string(input_.joy.index) + ' ' + hat_dir(input_.joy.value) + ")";
+        break;
+    case sdl_input_t::Type::MOUSE_BUTTON:
+        label = "Mouse(" + std::to_string(input_.mouse_button) + ")";
+        break;
+    }
+
+    setText(QString::fromStdString(label));
+}
+
+const std::unordered_map<Qt::Key, SDL_Keycode> QT_SDL_KEYMAP{
+    {Qt::Key_A, SDLK_a},
+    {Qt::Key_B, SDLK_b},
+    {Qt::Key_C, SDLK_c},
+    {Qt::Key_D, SDLK_d},
+    {Qt::Key_E, SDLK_e},
+    {Qt::Key_F, SDLK_f},
+    {Qt::Key_G, SDLK_g},
+    {Qt::Key_H, SDLK_h},
+    {Qt::Key_I, SDLK_i},
+    {Qt::Key_J, SDLK_j},
+    {Qt::Key_K, SDLK_k},
+    {Qt::Key_L, SDLK_l},
+    {Qt::Key_M, SDLK_m},
+    {Qt::Key_N, SDLK_n},
+    {Qt::Key_O, SDLK_o},
+    {Qt::Key_P, SDLK_p},
+    {Qt::Key_Q, SDLK_q},
+    {Qt::Key_R, SDLK_r},
+    {Qt::Key_S, SDLK_s},
+    {Qt::Key_T, SDLK_t},
+    {Qt::Key_U, SDLK_u},
+    {Qt::Key_V, SDLK_v},
+    {Qt::Key_W, SDLK_w},
+    {Qt::Key_X, SDLK_x},
+    {Qt::Key_Y, SDLK_y},
+    {Qt::Key_Z, SDLK_z},
+    {Qt::Key_0, SDLK_0},
+    {Qt::Key_1, SDLK_1},
+    {Qt::Key_2, SDLK_2},
+    {Qt::Key_3, SDLK_3},
+    {Qt::Key_4, SDLK_4},
+    {Qt::Key_5, SDLK_5},
+    {Qt::Key_6, SDLK_6},
+    {Qt::Key_7, SDLK_7},
+    {Qt::Key_8, SDLK_8},
+    {Qt::Key_9, SDLK_9},
+    {Qt::Key_F1, SDLK_F1},
+    {Qt::Key_F2, SDLK_F2},
+    {Qt::Key_F3, SDLK_F3},
+    {Qt::Key_F4, SDLK_F4},
+    {Qt::Key_F5, SDLK_F5},
+    {Qt::Key_F6, SDLK_F6},
+    {Qt::Key_F7, SDLK_F7},
+    {Qt::Key_F8, SDLK_F8},
+    {Qt::Key_F9, SDLK_F9},
+    {Qt::Key_F10, SDLK_F10},
+    {Qt::Key_F11, SDLK_F11},
+    {Qt::Key_F12, SDLK_F12},
+    {Qt::Key_F13, SDLK_F13},
+    {Qt::Key_F14, SDLK_F14},
+    {Qt::Key_F15, SDLK_F15},
+    {Qt::Key_Insert, SDLK_INSERT},
+    {Qt::Key_Delete, SDLK_DELETE},
+    {Qt::Key_Home, SDLK_HOME},
+    {Qt::Key_End, SDLK_END},
+    {Qt::Key_PageUp, SDLK_PAGEUP},
+    {Qt::Key_PageDown, SDLK_PAGEDOWN},
+    {Qt::Key_Up, SDLK_UP},
+    {Qt::Key_Down, SDLK_DOWN},
+    {Qt::Key_Left, SDLK_LEFT},
+    {Qt::Key_Right, SDLK_RIGHT},
+    {Qt::Key_Return, SDLK_RETURN},
+    {Qt::Key_Enter, SDLK_RETURN2},
+    {Qt::Key_Escape, SDLK_ESCAPE},
+    {Qt::Key_Pause, SDLK_PAUSE},
+    {Qt::Key_QuoteLeft, SDLK_QUOTEDBL},
+    {Qt::Key_Backspace, SDLK_BACKSPACE},
+    {Qt::Key_Tab, SDLK_TAB},
+    {Qt::Key_CapsLock, SDLK_CAPSLOCK},
+    {Qt::Key_Space, SDLK_SPACE},
+    {Qt::Key_Slash, SDLK_SLASH},
+    {Qt::Key_Backslash, SDLK_BACKSLASH},
+    {Qt::Key_Minus, SDLK_MINUS},
+    {Qt::Key_Plus, SDLK_UNKNOWN},
+    {Qt::Key_Equal, SDLK_EQUALS},
+    {Qt::Key_BracketLeft, SDLK_LEFTBRACKET},
+    {Qt::Key_BracketRight, SDLK_RIGHTBRACKET},
+    {Qt::Key_Semicolon, SDLK_SEMICOLON},
+    {Qt::Key_Apostrophe, SDLK_QUOTE},
+    {Qt::Key_Comma, SDLK_COMMA},
+    {Qt::Key_Period, SDLK_PERIOD},
+    {Qt::Key_Alt, SDLK_LALT},
+    {Qt::Key_Control, SDLK_LCTRL},
+    {Qt::Key_Shift, SDLK_LSHIFT},
+    {Qt::Key_Print, SDLK_PRINTSCREEN},
+    {Qt::Key_ScrollLock, SDLK_SCROLLLOCK},
+    {Qt::Key_Meta, SDLK_LGUI},
+    {Qt::Key_Super_L, SDLK_LGUI},
+    {Qt::Key_Super_R, SDLK_RGUI},
+    {Qt::Key_unknown, SDLK_UNKNOWN}
+};
+
+}

--- a/src/qt_gui/sdl_bind_button.hpp
+++ b/src/qt_gui/sdl_bind_button.hpp
@@ -1,0 +1,63 @@
+//
+// Created by henrik on 28.04.20.
+// Copyright 2020 Net64 Coop Project
+// Licensed under GPLv3
+// Refer to the LICENSE file included
+//
+
+#pragma once
+
+#include <QPushButton>
+#ifndef Q_MOC_RUN
+#include "common/sdl_event_handler.hpp"
+#include "net64/emulator/emulator.hpp"
+#endif
+
+
+namespace Frontend
+{
+
+struct SDL_BindButton : QPushButton, SDL_EventHandler
+{
+    Q_OBJECT
+
+public:
+    using sdl_input_t = Net64::Emulator::IControllerSettings::sdl_input_t;
+    using N64Button = Net64::Emulator::IControllerSettings::N64Button;
+
+    SDL_BindButton(QWidget* parent = nullptr);
+
+    void set_joystick(SDL_JoystickID joy_id);
+
+    void set_keyboard();
+
+    void set_settings_handle(Net64::Emulator::IControllerSettings* handle);
+
+    void load();
+
+    void save();
+
+    void set_bind(sdl_input_t input);
+
+    sdl_input_t get_bind();
+
+    void clear();
+
+
+    N64Button n64_button{};
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void handle_sdl_event(const SDL_Event& event) override;
+
+private:
+    void update_text();
+
+    sdl_input_t input_{};
+    bool listening_{};
+    SDL_JoystickID joy_id_{-1};
+    Net64::Emulator::IControllerSettings* settings_handle_{};
+};
+
+} // Frontend

--- a/src/qt_gui/sdl_bind_button.hpp
+++ b/src/qt_gui/sdl_bind_button.hpp
@@ -8,15 +8,13 @@
 #pragma once
 
 #include <QPushButton>
-#ifndef Q_MOC_RUN
+
 #include "common/sdl_event_handler.hpp"
 #include "net64/emulator/emulator.hpp"
-#endif
 
 
 namespace Frontend
 {
-
 struct SDL_BindButton : QPushButton, SDL_EventHandler
 {
     Q_OBJECT
@@ -60,4 +58,4 @@ private:
     Net64::Emulator::IControllerSettings* settings_handle_{};
 };
 
-} // Frontend
+} // namespace Frontend


### PR DESCRIPTION
Adds the ability to configure the emulator backend in the GUI (Resolves #13)

Settings to configure:
  - Emulator
    - Which emulator backend to use (currently only Mupen64Plus)
    - Mupen64Plus:
      - Path to binaries
      - Plugins
  - Controller
    - Button mappings
    - Input device
    - Configuration mode (automatic, manual)
    - Analog deadzone and peak
  - Video
    - Resolution
    - Fullscreen / windowed
    - VSync
  - Audio
    - Volume

Requires the following Mupen64Plus patches to work correctly:
  - [mupen64plus-input-sdl/91](https://github.com/mupen64plus/mupen64plus-input-sdl/pull/91)
  - [mupen64plus-core/758](https://github.com/mupen64plus/mupen64plus-core/pull/758)

Issues:
  - Input detection for axis whose neutral value is non zero does not work correctly
  - *Something* sets the `plugin` parameter for some controllers to `"2"` (string) instead of `2` (integer). Results in the controller pak not being able to be configured
  - After the emulation is stopped controller input events are no longer received. Button mappings can only be configured after a restart of the whole program

Linux build now uses Ubuntu bionic to get a newer Qt version and GCC-8